### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/request-read-access-to-use-template-for-a-workshop.md
+++ b/.github/ISSUE_TEMPLATE/request-read-access-to-use-template-for-a-workshop.md
@@ -12,7 +12,7 @@ assignees: ''
 
 #### Your information
 
-<!-- Add some basic information about yourself like your name and institution. If a GitHub user other than the one you are filing this issue from needs read access, tell us here -->
+<!-- Add some basic information about yourself like your name and institution. If a GitHub user other than the one you are filing this issue from needs read access, tell us here. -->
 
 #### Workshop format, location, and dates
 


### PR DESCRIPTION
Anyone with read access can use this repository as a template. I thought using this issue template for requesting read access might be a good way to collect/track information about workshops run by folks who are external to the CCDL. 