### PR TITLE
Add minima theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ _Optional_: remove the `.gitkeep` file from `slides`.
 - [ ] Update `_config.yaml` to use values that are relevant for your workshop such as the Docker repository and tag that you will be using for the workshop. [We use jekyll variable substitution as part of this template](https://jekyllrb.com/docs/includes/#passing-parameter-variables-to-includes).
 - [ ] Update `workshop/SCHEDULE.md` to point to appropriate materials for your workshop.
 	- Add relative links to PDFs in `slides` to the schedule.
-	- We recommend using [htmlpreview](https://github.com/htmlpreview/htmlpreview.github.com) to display rendered versions of R Notebooks that are tied to a specific release in the [`AlexsLemonade/training-modules`](https://github.com/AlexsLemonade/training-modules). You can use the `{{site.release-tag}}` convention used throughout the template.
+	- We recommend using [htmlpreview](https://github.com/htmlpreview/htmlpreview.github.com) to display rendered versions of R Notebooks that are tied to a specific release in the [`AlexsLemonade/training-modules`](https://github.com/AlexsLemonade/training-modules). You can use the `{{site.release_tag}}` convention used throughout the template.
 - [ ] Remove these instructions (and most likely the local development instructions below) from this README!
 We recommend that you link to `<url for repository's GitHub pages>/workshop/HOME` in the README, as this is where you will likely want most users to start to interact with the repository.
 

--- a/_config.yaml
+++ b/_config.yaml
@@ -25,4 +25,9 @@ docker_size: SIZE
 training_zip: TRAINING-ZIP
 training_unzip_folder: TRAINING-UNZIP-FOLDER
 
+# Theme and theme options
+theme: minima
+header_pages:
+  - virtual-workshop/SCHEDULE.md
+  - virtual-workshop/workshop-structure.md
   - virtual-workshop/workshop-materials.md

--- a/_config.yaml
+++ b/_config.yaml
@@ -1,25 +1,28 @@
+title: CCDL Training
 training_title: MONTH-TOPIC
 # The name of the repository (e.g., 2020-may-training)
 # We use training-specific-template to help with development
 repository: training-specific-template
 # Full URL to the repository
 # Again, using training-specific-template to aid in development
-repository-url: https://github.com/AlexsLemonade/training-specific-template
-start-date: YYYY-MM-DD
-end-date: YYYY-MM-DD
+repository_url: https://github.com/AlexsLemonade/training-specific-template
+start_date: YYYY-MM-DD
+end_date: YYYY-MM-DD
 # Specific release in AlexsLemonade/training-modules
 # We use master to make development easier
-release-tag: master
+release_tag: master
 # The Docker user will almost always be ccdl, which is why this is here
-docker-user: ccdl
-docker-repo: DOCKER-REPOSITORY
-docker-tag: DOCKER-TAG
+docker_user: ccdl
+docker_repo: DOCKER-REPOSITORY
+docker_tag: DOCKER-TAG
 # These are for loading Docker images from a file; only relevant for in-person
-docker-targz: ccdl_docker_image.tar.gz
-docker-tar: ccdl_docker_image.tar
+docker_targz: ccdl_docker_image.tar.gz
+docker_tar: ccdl_docker_image.tar
 # The image ID and size can be obtained by running `docker images` once you have a copy of the correct image for the training
-docker-image-id: IMAGEID
-docker-size: SIZE
+docker_image_id: IMAGEID
+docker_size: SIZE
 # How we have historically distributed materials in-person
-training-zip: TRAINING-ZIP
-training-unzip-folder: TRAINING-UNZIP-FOLDER
+training_zip: TRAINING-ZIP
+training_unzip_folder: TRAINING-UNZIP-FOLDER
+
+  - virtual-workshop/workshop-materials.md

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,0 +1,41 @@
+<footer class="site-footer h-card">
+  <!-- <data class="u-url" href="{{ "/" | relative_url }}"></data> -->
+
+  <div class="wrapper">
+
+    <div class="footer-col-wrapper">
+      <div class="footer-col">
+        <!-- No feed, so lets cut this out
+        <p class="feed-subscribe">
+          <a href="{{ 'feed.xml' | relative_url }}">
+            <svg class="svg-icon orange">
+              <use xlink:href="{{ 'assets/minima-social-icons.svg#rss' | relative_url }}"></use>
+            </svg><span>Subscribe</span>
+          </a>
+        </p>
+        -->
+      {%- if site.author %}
+        <ul class="contact-list">
+          {% if site.author.name -%}
+            <li class="p-name">{{ site.author.name | escape }}</li>
+          {% endif -%}
+          {% if site.author.email -%}
+            <li><a class="u-email" href="mailto:{{ site.author.email }}">{{ site.author.email }}</a></li>
+          {%- endif %}
+        </ul>
+      {%- endif %}
+      </div>
+      <!--- Don't include the site description
+      <div class="footer-col">
+        <p>{{ site.description | escape }}</p>
+      </div>
+      -->
+    </div>
+
+    <div class="social-links">
+      {%- include social.html -%}
+    </div>
+
+  </div>
+
+</footer>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,0 +1,38 @@
+<header class="site-header">
+
+  <div class="wrapper">
+    {%- assign default_paths = site.pages | map: "path" -%}
+    {%- assign page_paths = site.header_pages | default: default_paths -%}
+    {%- assign titles_size = site.pages | map: 'title' | join: '' | size -%}
+    <a class="site-title" rel="author" href="{{ "/" | relative_url }}">{{ site.title | escape }}</a>
+
+    {%- if titles_size > 0 -%}
+      <nav class="site-nav">
+        <input type="checkbox" id="nav-trigger" class="nav-trigger" />
+        <label for="nav-trigger">
+          <span class="menu-icon">
+            <svg viewBox="0 0 18 15" width="18px" height="15px">
+              <path d="M18,1.484c0,0.82-0.665,1.484-1.484,1.484H1.484C0.665,2.969,0,2.304,0,1.484l0,0C0,0.665,0.665,0,1.484,0 h15.032C17.335,0,18,0.665,18,1.484L18,1.484z M18,7.516C18,8.335,17.335,9,16.516,9H1.484C0.665,9,0,8.335,0,7.516l0,0 c0-0.82,0.665-1.484,1.484-1.484h15.032C17.335,6.031,18,6.696,18,7.516L18,7.516z M18,13.516C18,14.335,17.335,15,16.516,15H1.484 C0.665,15,0,14.335,0,13.516l0,0c0-0.82,0.665-1.483,1.484-1.483h15.032C17.335,12.031,18,12.695,18,13.516L18,13.516z"/>
+            </svg>
+          </span>
+        </label>
+
+        <div class="trigger">
+          {%- for path in page_paths -%}
+            {%- assign my_page = site.pages | where: "path", path | first -%}
+            {%- if my_page.nav_title -%}
+              {%- assign nav_title = my_page.nav_title -%}
+            {%- else -%}
+              {%- if my_page.title -%}
+                {%- assign nav_title = my_page.title -%}
+              {%- endif -%}
+            {%- endif -%}
+
+            {%- if nav_title -%}
+              <a class="page-link" href="{{ my_page.url | relative_url }}">{{ nav_title | escape }}</a>
+            {%- endif -%}
+          {%- endfor -%}
+        </div>
+      </nav>
+    {%- endif -%}
+  </div>

--- a/docker-install/INSTALLATION-INSTRUCTIONS.md
+++ b/docker-install/INSTALLATION-INSTRUCTIONS.md
@@ -1,4 +1,6 @@
-# Installing Docker
+---
+title: Installing Docker
+---
 
 Follow the instructions below for Mac and Windows operating systems.
 When you are finished, return to the schedule for your workshop for the link to the next steps.

--- a/docker-install/why-docker.md
+++ b/docker-install/why-docker.md
@@ -1,4 +1,7 @@
-# Why Docker?
+---
+title: Why Docker?
+---
+
 ## A brief intro to Docker as a data analysis tool
 
 For this workshop, we will be conducting all of our analyses in a [Docker container](https://www.docker.com/resources/what-container).

--- a/in-person-workshop/HOME.md
+++ b/in-person-workshop/HOME.md
@@ -1,6 +1,9 @@
-# CCDL Training: `<Training Title>`
+---
+title: CCDL Training
+---
+## {{site.training_title}}
 
-Dates: `<START>` through `<END>`
+Dates: {{site.start_date}} through {{site.end_date}}
 
 ## Getting Started
 

--- a/in-person-workshop/SCHEDULE.md
+++ b/in-person-workshop/SCHEDULE.md
@@ -1,3 +1,6 @@
-# Workshop Schedule
+---
+title: Workshop Schedule
+nav_title: Schedule
+---
 
 <!--PLACEHOLDER-->

--- a/in-person-workshop/docker-load.md
+++ b/in-person-workshop/docker-load.md
@@ -1,4 +1,6 @@
-# Docker Container Set Up - from Flashdrive
+---
+title: Docker Container Set Up - from Flashdrive
+---
 
 If you have successfully installed [Docker](../docker-install/INSTALLATION-INSTRUCTIONS.md),
 and have [copied the files from the flash drive](flashdrive-instructions.md),

--- a/in-person-workshop/docker-load.md
+++ b/in-person-workshop/docker-load.md
@@ -9,7 +9,7 @@ provide you with all the software and packages you need for this workshop.
 
 ## Part 1: Get the Docker image using a copy from the flash drives
 
-1. Be sure that you have copied `{{site.docker-targz}}` from the flash drive
+1. Be sure that you have copied `{{site.docker_targz}}` from the flash drive
 as was instructed in [these steps](flashdrive-instructions.md). If you do not
 have this file yet, follow [those instructions](flashdrive-instructions.md) before
 attempting to complete these next steps.
@@ -32,13 +32,13 @@ cd Desktop
 4. Once you are in your Desktop directory, you must extract the file with the following command:
 
 ```
-gunzip {{site.docker-targz}}
+gunzip {{site.docker_targz}}
 ```
 
 5. You can then load the Docker image with `docker load`:
 
 ```
-docker load -i {{site.docker-tar}}
+docker load -i {{site.docker_tar}}
 ```
 
 This will take a minute.
@@ -53,7 +53,7 @@ You should see output like:
 
 ```
 REPOSITORY                         TAG                 IMAGE ID            CREATED             SIZE
-{{site.docker-user}}/{{site.docker-repo}}                            {{site.docker-tag}}               {{site.docker-image-id}}       19 minutes ago        {{site.docker-size}}
+{{site.docker_user}}/{{site.docker_repo}}                            {{site.docker_tag}}               {{site.docker_image_id}}       19 minutes ago        {{site.docker_size}}
 ```
 
 _Note that the created field may not match._
@@ -62,9 +62,9 @@ _Note that the created field may not match._
 
 2. Install 7-Zip install if you do not already have it by downloading the `64-bit x64` program here: https://www.7-zip.org/
 
-3. Right-click `{{site.docker-targz}}`.
+3. Right-click `{{site.docker_targz}}`.
 4. Go to `7-Zip` and selected `Extract Here`.
-When that has finished extraction, you should see `{{site.docker-tar}}` on your Desktop.
+When that has finished extraction, you should see `{{site.docker_tar}}` on your Desktop.
 
 5. Open your `Command Prompt` application.
 6. Navigate to your `Desktop` directory with:
@@ -75,7 +75,7 @@ cd Desktop
 7. You can load the Docker image with `docker load`:
 
 ```
-docker load -i {{site.docker-tar}}
+docker load -i {{site.docker_tar}}
 ```
 
 This will take a minute.
@@ -90,7 +90,7 @@ You should see output like:
 
 ```
 REPOSITORY                         TAG                 IMAGE ID            CREATED             SIZE
-{{site.docker-user}}/{{site.docker-repo}}                            {{site.docker-tag}}               {{site.docker-image-id}}       19 minutes ago        {{site.docker-size}}
+{{site.docker_user}}/{{site.docker_repo}}                            {{site.docker_tag}}               {{site.docker_image_id}}       19 minutes ago        {{site.docker_size}}
 ```
 
 _Note that the created field may not match._
@@ -101,7 +101,7 @@ _Note that the created field may not match._
   like. **Make sure to get rid of `<` and `>`.** Also note that your chosen PASSWORD
   cannot have a `$`.
 ```
-docker run -e PASSWORD=<PASSWORD> -p 8787:8787 {{site.docker-user}}/{{site.docker-repo}}:{{site.docker-tag}} 
+docker run -e PASSWORD=<PASSWORD> -p 8787:8787 {{site.docker_user}}/{{site.docker_repo}}:{{site.docker_tag}} 
 ```
 
 2. Open `Kitematic` - you should see an image running. Docker assigns a random
@@ -158,7 +158,7 @@ If all else fails and Kitematic is not working for you, go to your `Terminal` or
 replace <PATH_TO_TRAINING_FOLDERS> with the absolute path to
 `training-modules` that was transferred from the flash drive.
 ```
-docker run -it --rm --mount type=volume,dst=/home/rstudio/kitematic,volume-driver=local,volume-opt=type=none,volume-opt=o=bind,volume-opt=device=<PATH_TO_TRAINING_FOLDERS> -e PASSWORD=<PASSWORD> -p 8787:8787 {{site.docker-user}}/{{site.docker-repo}}:{{site.docker-tag}}
+docker run -it --rm --mount type=volume,dst=/home/rstudio/kitematic,volume-driver=local,volume-opt=type=none,volume-opt=o=bind,volume-opt=device=<PATH_TO_TRAINING_FOLDERS> -e PASSWORD=<PASSWORD> -p 8787:8787 {{site.docker_user}}/{{site.docker_repo}}:{{site.docker_tag}}
 ```
 After starting your container this way, you can get to the RStudio window in
 a similar way as described above:

--- a/in-person-workshop/docker-pull.md
+++ b/in-person-workshop/docker-pull.md
@@ -14,13 +14,13 @@ provide you with all the software and packages you need for this workshop.
 
   In your respective command line interface, copy and paste the following:
 ```
-docker pull {{site.docker-user}}/{{site.docker-repo}}:{{site.docker-tag}} 
+docker pull {{site.docker_user}}/{{site.docker_repo}}:{{site.docker_tag}} 
 ```
 
 2. Run the container. Change the `<PASSWORD>` in the line below to whatever you'd
   like.
 ```
-docker run -e PASSWORD=<PASSWORD> -p 8787:8787 {{site.docker-user}}/{{site.docker-repo}}:{{site.docker-tag}} 
+docker run -e PASSWORD=<PASSWORD> -p 8787:8787 {{site.docker_user}}/{{site.docker_repo}}:{{site.docker_tag}} 
 ```
 
 3. Open `Kitematic` - you should see an image running. Docker assigns a random
@@ -77,7 +77,7 @@ If all else fails and Kitematic is not working for you, go to your `Terminal` or
 replace <PATH_TO_TRAINING_FOLDERS> with the absolute path to
 `training-modules` that was transferred from the flash drive.
 ```
-docker run -it --rm --mount type=volume,dst=/home/rstudio/kitematic,volume-driver=local,volume-opt=type=none,volume-opt=o=bind,volume-opt=device=<PATH_TO_TRAINING_FOLDERS> -e PASSWORD=<PASSWORD> -p 8787:8787 {{site.docker-user}}/{{site.docker-repo}}:{{site.docker-tag}} 
+docker run -it --rm --mount type=volume,dst=/home/rstudio/kitematic,volume-driver=local,volume-opt=type=none,volume-opt=o=bind,volume-opt=device=<PATH_TO_TRAINING_FOLDERS> -e PASSWORD=<PASSWORD> -p 8787:8787 {{site.docker_user}}/{{site.docker_repo}}:{{site.docker_tag}} 
 ```
 After starting your container this way, you can get to the RStudio window in
 a similar way as described above:

--- a/in-person-workshop/docker-pull.md
+++ b/in-person-workshop/docker-pull.md
@@ -1,4 +1,6 @@
-# Docker Container Set Up - from Internet
+---
+title: Docker Container Set Up - from Internet
+---
 
 If you have successfully installed [Docker](../docker-install/INSTALLATION-INSTRUCTIONS.md),
 and have copied the files from the [flash drive](flashdrive-instructions.md)

--- a/in-person-workshop/flashdrive-instructions.md
+++ b/in-person-workshop/flashdrive-instructions.md
@@ -1,4 +1,6 @@
-# Getting Workshop Data from Flash Drives
+---
+title: Getting Workshop Data from Flash Drives
+---
 
 Before starting these steps, you will want to be sure you have **50-60 GB** of free
 space on your computer.

--- a/in-person-workshop/flashdrive-instructions.md
+++ b/in-person-workshop/flashdrive-instructions.md
@@ -3,19 +3,19 @@
 Before starting these steps, you will want to be sure you have **50-60 GB** of free
 space on your computer.
 
-1. Copy `{{site.training-zip}}` and `<docker image tar.gz file>` to a place where
+1. Copy `{{site.training_zip}}` and `<docker image tar.gz file>` to a place where
 you can easily find them, such as your Desktop.
 
 ![flashdrive](screenshots/flashdrive_contents.png)
 
 2. Once you have copied these files, pass the flash drive off to the next person.
 
-3. Extract the contents of the zip file `{{site.training-zip}}`. On most operating
+3. Extract the contents of the zip file `{{site.training_zip}}`. On most operating
 systems you can double click the zip file, or right click and choose `Extract`.
 Note: *after* this has *successfully* extracted, you can feel free to
-delete the original `{{site.training-zip}}` if you would like.
+delete the original `{{site.training_zip}}` if you would like.
 
-4. `{{site.training-unzip-folder}}/training-modules` is the main directory we will be using.
+4. `{{site.training_unzip_folder}}/training-modules` is the main directory we will be using.
 
 5. Now you can follow the Docker container set up instructions.
 Use the instructions linked on the [schedule](./SCHEDULE.md) for `Docker container set up`.

--- a/optional-workshop-prep/R-prep.md
+++ b/optional-workshop-prep/R-prep.md
@@ -1,4 +1,6 @@
-# Pre-Workshop Prep for R Programming
+---
+title: Pre-Workshop Prep for R Programming
+---
 
 If you have little to no experience with R, we strongly recommend that you go through some of these swirl course materials before our workshop.
 We will iterate through these concepts in the context of gene expression data at the workshop. 

--- a/virtual-setup/README.md
+++ b/virtual-setup/README.md
@@ -1,4 +1,6 @@
-## Setup for CCDL Virtual Workshops
+---
+title: Setup for CCDL Virtual Workshops
+---
 
 The `virtual-setup` module houses instructions specifically for CCDL virtual training workshops.
 

--- a/virtual-setup/linux-instructions.md
+++ b/virtual-setup/linux-instructions.md
@@ -1,4 +1,6 @@
-## Linux set up instructions for virtual workshops
+---
+title: Linux set up instructions for virtual workshops
+---
 
 TOC
 

--- a/virtual-setup/mac-instructions.md
+++ b/virtual-setup/mac-instructions.md
@@ -1,5 +1,6 @@
-# Mac Setup Instructions for Virtual Workshops
-
+---
+title: Mac Setup Instructions for Virtual Workshops
+---
 
 ## Table of Contents
 

--- a/virtual-setup/rstudio-login.md
+++ b/virtual-setup/rstudio-login.md
@@ -3,7 +3,7 @@
 For this training, we've set up a server that hosts RStudio and allows you to run computations more quickly with our machines.
 
 In this tutorial, we will get you set up with our server.
-In our [RStudio guide](https://github.com/AlexsLemonade/training-modules/blob/{{site.release-tag}}/intro-to-R-tidyverse/00a-rstudio_guide.md) and our [`intro-to-R-tidyverse` module](https://github.com/AlexsLemonade/training-modules/blob/{{site.release-tag}}/intro-to-R-tidyverse) we will work on becoming more comfortable with R and RStudio for programing.
+In our [RStudio guide](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/00a-rstudio_guide.md) and our [`intro-to-R-tidyverse` module](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse) we will work on becoming more comfortable with R and RStudio for programing.
 RStudio by itself is an [integrated development environment](https://en.wikipedia.org/wiki/Integrated_development_environment) or IDE that makes it easier to program in R.
 
 ### Logging in
@@ -117,7 +117,7 @@ Back on the session page, you are able to see the current files in your `home` d
 In your `home` directory, you will find the `training-modules` folder that contains our course materials and the `shared-data` that contains the data we will be using in the modules.
 The files in these folders are accessible in each R session you start.
 Starting and stopping R sessions will refresh what is in your `Environment` tab in the upper right panel.
-We go into more detail on the R environment and other RStudio navigating tidbits in our [guide to RStudio](https://github.com/AlexsLemonade/training-modules/blob/{{site.release-tag}}/intro-to-R-tidyverse/00a-rstudio_guide.md) as well as our [first intro to R notebook](https://github.com/AlexsLemonade/training-modules/blob/{{site.release-tag}}/intro-to-R-tidyverse/01-intro_to_base_R.Rmd).
+We go into more detail on the R environment and other RStudio navigating tidbits in our [guide to RStudio](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/00a-rstudio_guide.md) as well as our [first intro to R notebook](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/intro-to-R-tidyverse/01-intro_to_base_R.Rmd).
 
 As always, please reach out to our CCDL team through Slack if you have any questions!
 

--- a/virtual-setup/rstudio-login.md
+++ b/virtual-setup/rstudio-login.md
@@ -1,4 +1,6 @@
-## RStudio Server Set Up
+---
+title: RStudio Server Set Up
+---
 
 For this training, we've set up a server that hosts RStudio and allows you to run computations more quickly with our machines.
 

--- a/virtual-setup/slack-procedures.md
+++ b/virtual-setup/slack-procedures.md
@@ -1,5 +1,6 @@
-# Using Slack for CCDL virtual workshops
-
+---
+title: Using Slack for CCDL virtual workshops
+---
 We use Slack for communication during CCDL virtual workshops.
 
 <p><img style = "padding: 0 15px; float: left;" src = "screenshots/slack-cancer-data-science-logo.png" width = "75"></p>
@@ -22,9 +23,9 @@ We have instructions for setting up Slack for your operating system available.
 
 - [How we use Slack during workshops](#how-we-use-slack-during-workshops)
   - [Using the training-specific channel](#using-the-training-specific-channel)
-     - [Introduce yourself!](#introduce-yourself)
-     - [General use](#general-use)
-     - [Collecting feedback](#collecting-feedback)
+    - [Introduce yourself!](#introduce-yourself)
+    - [General use](#general-use)
+    - [Collecting feedback](#collecting-feedback)
   - [Using Slack calling during training](#using-slack-calling-during-training)
   - [Using direct messages during training](#using-direct-messages-during-training)
 - [General Slack use](#general-slack-use)

--- a/virtual-setup/windows-instructions.md
+++ b/virtual-setup/windows-instructions.md
@@ -1,4 +1,6 @@
-# Windows set up instructions for virtual workshops
+---
+title: Windows set up instructions for virtual workshops
+---
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->

--- a/virtual-setup/working-with-your-own-data.md
+++ b/virtual-setup/working-with-your-own-data.md
@@ -1,4 +1,6 @@
-## Working with your own data
+---
+title: Working with your own data
+---
 
 The goal of our workshop is to equip you to do initial analyses with your own data!
 This guide will take you through how to get your data onto our RStudio server so you can begin analyzing your own data!

--- a/virtual-setup/zoom-procedures.md
+++ b/virtual-setup/zoom-procedures.md
@@ -1,5 +1,6 @@
-# Zoom Procedures for CCDL Virtual Workshops
-
+---
+title: Zoom Procedures for CCDL Virtual Workshops
+---
 We use [Zoom](https://zoom.us/) meetings for conducting CCDL virtual workshops.
 In this document, we will cover the procedures for joining a Zoom call and using various features for instruction and consultation sessions.
 

--- a/virtual-workshop/HOME.md
+++ b/virtual-workshop/HOME.md
@@ -1,7 +1,7 @@
-
 ---
 title: CCDL Virtual Training
 ---
+
 ## {{site.training_title}}
 
 Dates: {{site.start_date}} through {{site.end_date}}

--- a/virtual-workshop/HOME.md
+++ b/virtual-workshop/HOME.md
@@ -1,6 +1,10 @@
-# CCDL Virtual Training: {{site.training_title}}
 
-Dates: {{site.start-date}} through {{site.end-date}}
+---
+title: CCDL Virtual Training
+---
+## {{site.training_title}}
+
+Dates: {{site.start_date}} through {{site.end_date}}
 
 ## Getting Started
 

--- a/virtual-workshop/SCHEDULE.md
+++ b/virtual-workshop/SCHEDULE.md
@@ -1,5 +1,7 @@
-
-# Virtual Workshop Schedule
+---
+title: Virtual Workshop Schedule
+nav_title: Schedule
+---
 
 <!--See an example from a past virtual workshop here: https://github.com/AlexsLemonade/2020-may-training/wiki/Schedule --> 
 

--- a/virtual-workshop/resources-for-consultation-sessions.md
+++ b/virtual-workshop/resources-for-consultation-sessions.md
@@ -1,4 +1,6 @@
-# Resources for Consultation Sessions
+---
+title: Resources for Consultation Sessions
+---
 
 Our consultation sessions are designed for you to spend your time as you would like with the support of your instructors.
 
@@ -12,7 +14,7 @@ On this page, we've assembled some resources you may find helpful during these s
 - [Working with your own data on RStudio Server](#working-with-your-own-data-on-rstudio-server)
 - [Obtaining practice datasets](#obtaining-practice-datasets)
   - [Microarray data](#microarray-data)
-  - [RNA-seq data](#rnaseq-data)
+  - [RNA-seq data](#rna-seq-data)
     - [Getting a copy of the SRAdb example notebook in your home directory on RStudio Server](#getting-a-copy-of-the-sradb-example-notebook-in-your-home-directory-on-rstudio-server)
 - [Transcriptome indices for non-human organisms](#transcriptome-indices-for-non-human-organisms)
   - [_Mus musculus_](#mus-musculus)
@@ -21,10 +23,10 @@ On this page, we've assembled some resources you may find helpful during these s
 
 ## Module cheatsheets
 
-The [`modules-cheatsheets` directory](https://github.com/AlexsLemonade/training-modules/tree/{{site.release-tag}}/module-cheatsheets) of our [GitHub repository of training materials](https://github.com/AlexsLemonade/training-modules) contains Markdown and PDF version of "cheatsheets" that contain tables with short descriptions of functions used throughout training modules and links to documentation.
+The [`modules-cheatsheets` directory](https://github.com/AlexsLemonade/training-modules/tree/{{site.release_tag}}/module-cheatsheets) of our [GitHub repository of training materials](https://github.com/AlexsLemonade/training-modules) contains Markdown and PDF version of "cheatsheets" that contain tables with short descriptions of functions used throughout training modules and links to documentation.
 
-* Introduction to R/Tidyverse cheatsheet ([View Markdown](https://github.com/AlexsLemonade/training-modules/blob/{{site.release-tag}}/module-cheatsheets/intro-to-R-tidyverse-cheatsheet.md), [Download PDF](https://github.com/AlexsLemonade/training-modules/raw/{{site.release-tag}}/module-cheatsheets/intro-to-R-tidyverse-cheatsheet.pdf))
-* RNA-seq module cheatsheet ([View Markdown](https://github.com/AlexsLemonade/training-modules/blob/{{site.release-tag}}/module-cheatsheets/RNA-seq-cheatsheet.md), [Download PDF](https://github.com/AlexsLemonade/training-modules/raw/{{site.release-tag}}/module-cheatsheets/RNA-seq-cheatsheet.pdf))
+* Introduction to R/Tidyverse cheatsheet ([View Markdown](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/module-cheatsheets/intro-to-R-tidyverse-cheatsheet.md), [Download PDF](https://github.com/AlexsLemonade/training-modules/raw/{{site.release_tag}}/module-cheatsheets/intro-to-R-tidyverse-cheatsheet.pdf))
+* RNA-seq module cheatsheet ([View Markdown](https://github.com/AlexsLemonade/training-modules/blob/{{site.release_tag}}/module-cheatsheets/RNA-seq-cheatsheet.md), [Download PDF](https://github.com/AlexsLemonade/training-modules/raw/{{site.release_tag}}/module-cheatsheets/RNA-seq-cheatsheet.pdf))
 
 You may find these helpful as you review instruction material or work through exercise notebooks.
 

--- a/virtual-workshop/software-setup.md
+++ b/virtual-workshop/software-setup.md
@@ -1,4 +1,6 @@
-# Software Setup
+---
+title: Software Setup
+---
 
 ## Required software
 

--- a/virtual-workshop/using-docker-post-workshop.md
+++ b/virtual-workshop/using-docker-post-workshop.md
@@ -26,7 +26,7 @@ Once you've installed Docker and Kitematic, you will need to pull the appropriat
 In your respective command line interface, copy and paste the following:
 
 ```
-docker pull {{site.docker-user}}/{{site.docker-repo}}:{{site.docker-tag}}
+docker pull {{site.docker_user}}/{{site.docker_repo}}:{{site.docker_tag}}
 ```
 
 #### Running and interacting with the container
@@ -34,7 +34,7 @@ docker pull {{site.docker-user}}/{{site.docker-repo}}:{{site.docker-tag}}
 To run the container, change the `<PASSWORD>` in the line below to whatever you'd like.
 
 ```
-docker run -e PASSWORD=<PASSWORD> -p 8787:8787 {{site.docker-user}}/{{site.docker-repo}}:{{site.docker-tag}}
+docker run -e PASSWORD=<PASSWORD> -p 8787:8787 {{site.docker_user}}/{{site.docker_repo}}:{{site.docker_tag}}
 ```
 
 **To work with files on your computer, you will need to set a local folder as your volume.**

--- a/virtual-workshop/using-docker-post-workshop.md
+++ b/virtual-workshop/using-docker-post-workshop.md
@@ -1,4 +1,6 @@
-# Using Docker (Post-Workshop)
+---
+title: Using Docker (Post-Workshop)
+---
 
 #### Background
 

--- a/virtual-workshop/workshop-materials.md
+++ b/virtual-workshop/workshop-materials.md
@@ -6,7 +6,7 @@ CCDL training materials are available on Github, in either this repository or ou
 
 ### Slides
 
-PDF versions of the slides we present in this workshop can be found in the [slides directory]({{site.repository-url}}/slides) of the `{{site.repository}}` repository, and are also linked to directly from the [schedule](./SCHEDULE.md).
+PDF versions of the slides we present in this workshop can be found in the [slides directory]({{site.repository_url}}/slides) of the `{{site.repository}}` repository, and are also linked to directly from the [schedule](./SCHEDULE.md).
 
 ### Module Structure
 
@@ -16,13 +16,13 @@ In this training workshop, we will be using the following modules:
 
 <!--List the specific modules you will be using and use permalinks to a specific release-->
 
-- [Intro to R and the Tidyverse](https://github.com/AlexsLemonade/training-modules/tree/{{site.release-tag}}/intro-to-R-tidyverse)
-- [RNA-Seq](https://github.com/AlexsLemonade/training-modules/tree/{{site.release-tag}}/RNA-seq)
+- [Intro to R and the Tidyverse](https://github.com/AlexsLemonade/training-modules/tree/{{site.release_tag}}/intro-to-R-tidyverse)
+- [RNA-Seq](https://github.com/AlexsLemonade/training-modules/tree/{{site.release_tag}}/RNA-seq)
 
 
 The layout of the `training-modules` folders follow a common general structure.
 
-<img src="https://github.com/AlexsLemonade/training-modules/raw/{{site.release-tag}}/module_structure_detail.png" alt="Module Structure" width="600">
+<img src="https://github.com/AlexsLemonade/training-modules/raw/{{site.release_tag}}/module_structure_detail.png" alt="Module Structure" width="600">
 
 In these folders, you will notice that there may be two or three versions of some notebook files.
 For example, there may be a `01-intro_to_base_R-live.Rmd`, a `01-intro_to_base_R.Rmd`, and a `01-intro_to_base_R.nb.html`.
@@ -31,7 +31,7 @@ For example, there may be a `01-intro_to_base_R-live.Rmd`, a `01-intro_to_base_R
 - The `.nb.html` version of the file is a rendered web page of the notebook.
 This file can be downloaded or viewed via the links in the README file that you will see at the bottom of file listing for each module.
 
-Cheatsheets that review key functions and concepts are found in the [module-cheatsheets folder](https://github.com/AlexsLemonade/training-modules/tree/{{site.release-tag}}/module-cheatsheets).
+Cheatsheets that review key functions and concepts are found in the [module-cheatsheets folder](https://github.com/AlexsLemonade/training-modules/tree/{{site.release_tag}}/module-cheatsheets).
 These are formatted both as markdown files and PDFs, with the latter likely most useful for reference.
 
 ### RStudio Server

--- a/virtual-workshop/workshop-materials.md
+++ b/virtual-workshop/workshop-materials.md
@@ -1,4 +1,7 @@
-# Workshop Materials
+---
+title: Workshop Materials
+nav_title: Materials
+---
 
 ### Github Repositories
 

--- a/virtual-workshop/workshop-structure.md
+++ b/virtual-workshop/workshop-structure.md
@@ -1,4 +1,7 @@
-# Workshop Structure
+---
+title: Workshop Structure
+nav_title: Structure
+---
 
 Our goals in constructing the virtual workshop structure are the following:
 


### PR DESCRIPTION
This PR adds the `minima` theme, with some modifications to allow the navbar title for linked pages to not be exactly the same as the page title.

In order for this to be done, I also converted all page titles (the first H1 element) to yaml front matter. 

The current form is for testing, as the final `_config.yaml` `header_pages` elements should point to `workshop/` not `virtual-workshop/`


