### PR TITLE
Fix link to Docker install instructions

### DIFF
--- a/virtual-workshop/using-docker-post-workshop.md
+++ b/virtual-workshop/using-docker-post-workshop.md
@@ -15,7 +15,7 @@ The image we use will allow you to access an RStudio Server in your local contai
 
 #### Docker installation
 
-You can find instructions for installing Docker on Mac OS or Windows 10 Pro [here](../workshop/INSTALLATION-INSTRUCTIONS.md).
+You can find instructions for installing Docker on Mac OS or Windows 10 Pro [here](../docker-install/INSTALLATION-INSTRUCTIONS.md).
 _Note: Windows Home has only recently become supported and requires different steps than what is linked above ([Docker documentation](https://docs.docker.com/docker-for-windows/install-windows-home/))._
 
 #### Obtaining the Docker image


### PR DESCRIPTION
This PR addresses issue #42.

As noted on the [upstream issue](https://github.com/AlexsLemonade/2020-july-training/issues/14) in the `2020-july-training` template repo, the link to the Docker installation instructions was broken as it was pointed to workshop/INSTALLATION-INSTRUCTIONS instead of docker-install/INSTALLATION-INSTRUCTIONS in "Using Docker Post-Workshop."

This PR fixes this link in this template repository.

As noted in the [almost identical PR in `2020-july-training`](https://github.com/AlexsLemonade/2020-july-training/pull/16), I searched for other instances and believe I fixed the only instance, but please let me know if I missed any along the way.