### PR TITLE
Use a workflow dispatch to create issues from markdown templates

### DIFF
--- a/.github/workflows/file-setup-issues.yml
+++ b/.github/workflows/file-setup-issues.yml
@@ -18,6 +18,9 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
 
+      # Check out  
+      - uses: actions/checkout@v2
+      
       # Issue for turning on GitHub pages
       - name: Create GitHub Pages issue
         uses: peter-evans/create-issue-from-file@v2.3.2

--- a/.github/workflows/file-setup-issues.yml
+++ b/.github/workflows/file-setup-issues.yml
@@ -1,0 +1,99 @@
+name: Manually trigger issue creation for standard set up
+
+# This is a manually triggered workflow
+# https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_dispatch
+# https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow#running-a-workflow-on-github
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: training-modules release tag for training workshop
+        required: true
+
+jobs:
+  # This runs a single job that creates issues from files 
+  createIssuesFromFile:
+    runs-on: ubuntu-latest
+    
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+
+      # Issue for turning on GitHub pages
+      - name: Create GitHub Pages issue
+        uses: peter-evans/create-issue-from-file@v2.3.2
+        with:
+          title: Turn on GitHub Pages
+          content-filepath: ./setup-issue-templates/gh-pages.md
+          labels: automated training issue
+      
+      # Issue for turning on branch protection
+      - name: Create branch protection issue
+        uses: peter-evans/create-issue-from-file@v2.3.2
+        with:
+          title: Set up branch protection - pull requests required
+          content-filepath: ./setup-issue-templates/branch-protection.md
+          labels: automated training issue
+
+      # Issue for deleting and renaming directories
+      - name: Create issue for deleting irrelevant folders
+        uses: peter-evans/create-issue-from-file@v2.3.2
+        with:
+          title: Delete irrelevant workshop directories and rename
+          content-filepath: ./setup-issue-templates/delete-directories-and-rename.md
+          labels: automated training issue
+      
+      # Issue updating `_config.yaml`
+      - name: Create issue for _config.yaml
+        uses: peter-evans/create-issue-from-file@v2.3.2
+        with:
+          title: Update _config.yaml to use values relevant to this workshop
+          content-filepath: ./setup-issue-templates/update-config.md
+          labels: automated training issue   
+           
+      # Issue for header pages
+      - name: Create issue for setting up header pages
+        uses: peter-evans/create-issue-from-file@v2.3.2
+        with:
+          title: Update the pages that will appear in the header
+          content-filepath: ./setup-issue-templates/update-header-pages.md
+          labels: automated training issue
+      
+      # Issue for adding PDF versions of slides
+      - name: Create issue for slides
+        uses: peter-evans/create-issue-from-file@v2.3.2
+        with:
+          title: Add PDF versions of slides to `slides`
+          content-filepath: ./setup-issue-templates/pdf-slides.md
+          labels: automated training issue, slides
+
+      # Issue for creating a draft version of schedule
+      - name: Create draft schedule issue
+        uses: peter-evans/create-issue-from-file@v2.3.2
+        with:
+          title: Draft version of schedule
+          content-filepath: ./setup-issue-templates/draft-schedule.md
+          labels: automated training issue, schedule
+
+      # Issue for creating a training-specific release of training-modules
+      - name: Create issue for training-specific release
+        uses: peter-evans/create-issue-from-file@v2.3.2
+        with:
+          title: Create ${{ github.event.inputs.tag }} release of training-modules
+          content-filepath: ./setup-issue-templates/workshop-release.md
+          labels: automated training issue
+      
+      # Issue for creating a final version of schedule
+      - name: Create final schedule issue
+        uses: peter-evans/create-issue-from-file@v2.3.2
+        with:
+          title: Final version of schedule
+          content-filepath: ./setup-issue-templates/final-schedule.md
+          labels: automated training issue, schedule
+
+      # Issue for updating README
+      - name: Create issue for updating README
+        uses: peter-evans/create-issue-from-file@v2.3.2
+        with:
+          title: Update README to be user-facing (remove instructions)
+          content-filepath: ./setup-issue-templates/user-facing-readme.md
+          labels: automated training issue

--- a/.github/workflows/file-setup-issues.yml
+++ b/.github/workflows/file-setup-issues.yml
@@ -91,7 +91,7 @@ jobs:
         with:
           title: Final version of schedule
           content-filepath: ./setup-issue-templates/final-schedule.md
-          labels: automated training issue, schedule
+          labels: automated training issue, schedule, blocked
 
       # Issue for updating README
       - name: Create issue for updating README

--- a/setup-issue-templates/branch-protection.md
+++ b/setup-issue-templates/branch-protection.md
@@ -1,0 +1,1 @@
+Require pull requests before merging on the default branch, under `Settings` > `Branches` > `Branch protection rules`. Require at least one approving review. 

--- a/setup-issue-templates/delete-directories-and-rename.md
+++ b/setup-issue-templates/delete-directories-and-rename.md
@@ -1,0 +1,7 @@
+- [ ] Delete the irrelevant `*-workshop` folder. 
+If your workshop is a virtual workshop, remove the `in-person-workshop` folder. 
+If your workshop is an in-person workshop, remove the `virtual-workshop` folder.
+	- If you're running an in-person workshop, you will not need the `virtual-setup` folder, either.
+- [ ] Rename the relevant `*-workshop` folder to `workshop`. 
+For a virtual workshop, `virtual-workshop` should be renamed to `workshop`.
+Changing this folder name will make several links in the repository work –there are instances where we link to a schedule with `../workshop/SCHEDULE.md`, for example.

--- a/setup-issue-templates/draft-schedule.md
+++ b/setup-issue-templates/draft-schedule.md
@@ -1,0 +1,4 @@
+Update `workshop/SCHEDULE.md` to point to appropriate materials for your workshop.
+
+  - Add relative links to PDFs in `slides` to the schedule.
+  - We recommend using [htmlpreview](https://github.com/htmlpreview/htmlpreview.github.com) to display rendered versions of R Notebooks that are tied to a specific release in the [`AlexsLemonade/training-modules`](https://github.com/AlexsLemonade/training-modules). You can use the `{{site.release_tag}}` convention used throughout the template.

--- a/setup-issue-templates/final-schedule.md
+++ b/setup-issue-templates/final-schedule.md
@@ -1,0 +1,3 @@
+Finalize the schedule once all content has been completed. 
+
+As a reminder, we recommend using [htmlpreview](https://github.com/htmlpreview/htmlpreview.github.com) in conjunction with `{{site.release_tag}}` to display rendered versions of R Notebooks that are tied to a specific release in the [`AlexsLemonade/training-modules`](https://github.com/AlexsLemonade/training-modules).

--- a/setup-issue-templates/gh-pages.md
+++ b/setup-issue-templates/gh-pages.md
@@ -1,0 +1,1 @@
+Turn on GitHub pages under `Settings` > `Options` > `GitHub Pages`. Use the default branch as the Source.

--- a/setup-issue-templates/pdf-slides.md
+++ b/setup-issue-templates/pdf-slides.md
@@ -1,0 +1,11 @@
+Add PDF copies of your slides to `slides`. _Optional_: remove the `.gitkeep` file from `slides`.
+
+#### Slides
+
+<!--Remove or alter this section depending on the workshop content-->
+
+- [ ] Introduction to the workshop
+- [ ] Day 1 slides
+- [ ] Day 2 slides
+- [ ] Day 3 slides
+- [ ] Day 4 slides

--- a/setup-issue-templates/update-config.md
+++ b/setup-issue-templates/update-config.md
@@ -1,0 +1,1 @@
+Update `_config.yaml` to use values that are relevant for your workshop such as the Docker repository and tag that you will be using for the workshop. [We use jekyll variable substitution as part of this template](https://jekyllrb.com/docs/includes/#passing-parameter-variables-to-includes).

--- a/setup-issue-templates/update-header-pages.md
+++ b/setup-issue-templates/update-header-pages.md
@@ -1,0 +1,1 @@
+Update the pages that will appear in the header (`header_pages:`) in `_config.yaml`. Any page that appears in the header should have a navigation title (`nav_title:`) in its YAML header.

--- a/setup-issue-templates/user-facing-readme.md
+++ b/setup-issue-templates/user-facing-readme.md
@@ -1,0 +1,3 @@
+Remove customization and development instructions from the README.
+
+Link to `<url for repository's GitHub pages>/workshop/HOME` in the README, as this is where we want most users to start to interact with the repository. 

--- a/setup-issue-templates/workshop-release.md
+++ b/setup-issue-templates/workshop-release.md
@@ -1,2 +1,3 @@
 In [`AlexsLemonade/training-modules`](https://github.com/AlexsLemonade/training-modules), [create a new release](https://github.com/AlexsLemonade/training-modules/releases/new) that ties that material to this specific workshop. We use the convention `<year>-<month>` for tags and `<year> <month>` for release titles for CCDL workshops.
 
+Don't forget to update the `_config.yaml` file in _this repository_ to point to the correct the release.

--- a/setup-issue-templates/workshop-release.md
+++ b/setup-issue-templates/workshop-release.md
@@ -1,0 +1,2 @@
+In [`AlexsLemonade/training-modules`](https://github.com/AlexsLemonade/training-modules), [create a new release](https://github.com/AlexsLemonade/training-modules/releases/new) that ties that material to this specific workshop. We use the convention `<year>-<month>` for tags and `<year> <month>` for release titles for CCDL workshops.
+


### PR DESCRIPTION
⚠️ _includes changes from #46_

Related to https://github.com/AlexsLemonade/training-admin/issues/421. I figured I would start with creating issues that are related to setting up a specific repository using this template repo.

Here I'm using a [`workflow_dispatch`](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_dispatch), which allows us to manually trigger a workflow from GitHub or via the GitHub API. The steps in the workflow use the [Create Issue from File](https://github.com/marketplace/actions/create-issue-from-file) GitHub Actions workflow to create issues from the `.md` files in `setup-issue-templates/`. 

The idea, which is not yet documented in the README, is that you would trigger this workflow as soon as you create a new repository from the template. All of the issues would automatically be tagged with an `automated training issue` label, which should make it straightforward to filter using this label on the ZenHub board -> bulk select -> add to an Epic.

There is a related manual event called a [`repository_dispatch`](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#repository_dispatch), which I _believe_ would allow us to create issues across multiple repositories. That would require us to use the API and probably be much less straightforward for us to maintain, so I'm not super enthusiastic about that.

**Note to reviewers:** Please take a look at [`peter-evans/create-issue-from-file@v2.3.2`](https://github.com/peter-evans/create-issue-from-file/tree/v2.3.2) as well.