### PR TITLE
Add an automated training issue for tailoring workshop content to a specific workshop

### DIFF
--- a/.github/workflows/file-setup-issues.yml
+++ b/.github/workflows/file-setup-issues.yml
@@ -100,3 +100,11 @@ jobs:
           title: Update README to be user-facing (remove instructions)
           content-filepath: ./setup-issue-templates/user-facing-readme.md
           labels: automated training issue
+
+      # Issue for updating course website to reflect workshop's content
+      - name: Create issue for revising workshop content
+        uses: peter-evans/create-issue-from-file@v2.3.2
+        with:
+          title: Ensure that descriptions of and links to workshop content are up-to-date
+          content-filepath: ./setup-issue-templates/tailor-to-workshop-content.md
+          labels: automated training issue

--- a/setup-issue-templates/tailor-to-workshop-content.md
+++ b/setup-issue-templates/tailor-to-workshop-content.md
@@ -1,0 +1,6 @@
+Revise the course website to reflect the content this workshop will be covering. 
+
+For virtual workshops, the areas that need to be updated are:
+
+* The first bulletpoint in `virtual-workshop/workshop-structure.md` (which becomes `workshop/workshop-structure.md`)
+* The modules we link to in `virtual-workshop/workshop-materials.md` (which becomes `workshop/workshop-materials.md`)


### PR DESCRIPTION
Closes #67 - we will now have an automatically created issue that tracks making sure the course website links to and describes the correct content for a given workshop.