### PR TITLE
Update `slack-procedures.md` to reflect most current team members

### DIFF
--- a/virtual-setup/slack-procedures.md
+++ b/virtual-setup/slack-procedures.md
@@ -36,7 +36,7 @@ We have instructions for setting up Slack for your operating system available.
 
 Course instructors will add you to a private channel specific to your training a few days before the start of your training workshop.
 
-If you are not added to the training specific channel by 3 days prior to the start of training or are having trouble getting started with Slack, please [direct message](#using-direct-messages-during-training) a CCDL staff member (`Chante Bethell`, `Candace Savonen`, `Josh Shapiro` or `Jaclyn N. Taroni`) in Cancer Data Science Slack or email [training@ccdatalab.org](mailto:training@ccdatalab.org).
+If you are not added to the training specific channel by 3 days prior to the start of training or are having trouble getting started with Slack, please [direct message](#using-direct-messages-during-training) a CCDL staff member (`Chante Bethell`, `Ally Hawkins`, `Jen O'Malley` or `Josh Shapiro`) in Cancer Data Science Slack or email [training@ccdatalab.org](mailto:training@ccdatalab.org).
 
 ### Using the training-specific channel
 
@@ -105,7 +105,7 @@ First, use the new message button in the top right side corner of the Slack inte
 
 <img src = "screenshots/slack-compose-new-message.png" width="300">
 
-You are then able to search for the CCDL instructors – `Chante Bethell`, `Candace Savonen`, `Josh Shapiro` or `Jaclyn N. Taroni` – and compose your message.
+You are then able to search for the CCDL instructors – `Chante Bethell`, `Ally Hawkins`, `Jen O'Malley` or `Josh Shapiro` – and compose your message.
 
 Course instructors may direct you to the training-specific channel for more general questions or to another instructor where appropriate.
 


### PR DESCRIPTION
Per https://github.com/AlexsLemonade/2021-september-training/pull/13#pullrequestreview-716123850, this PR updates the `slack-procedures.md` to reflect the most current team members participants should contact via Slack.

The additions in https://github.com/AlexsLemonade/2021-september-training/pull/13 were propagated here (as well as the removal of Jackie from the _rotation_).