### PR TITLE
Minor page updates

### DIFF
--- a/in-person-workshop/HOME.md
+++ b/in-person-workshop/HOME.md
@@ -1,5 +1,5 @@
 ---
-title: CCDL Training
+title: ALSF Data Lab Training
 nav_title: Home
 permalink: /
 ---

--- a/setup-issue-templates/workshop-release.md
+++ b/setup-issue-templates/workshop-release.md
@@ -1,3 +1,3 @@
 In [`AlexsLemonade/training-modules`](https://github.com/AlexsLemonade/training-modules), [create a new release](https://github.com/AlexsLemonade/training-modules/releases/new) that ties that material to this specific workshop. We use the convention `<year>-<month>` for tags and `<year> <month>` for release titles for Data Lab workshops.
 
-Don't forget to update the `_config.yaml` file in _this repository_ to point to the correct the release.
+Don't forget to update the `_config.yaml` file in _this repository_ to point to the correct release.

--- a/setup-issue-templates/workshop-release.md
+++ b/setup-issue-templates/workshop-release.md
@@ -1,3 +1,3 @@
-In [`AlexsLemonade/training-modules`](https://github.com/AlexsLemonade/training-modules), [create a new release](https://github.com/AlexsLemonade/training-modules/releases/new) that ties that material to this specific workshop. We use the convention `<year>-<month>` for tags and `<year> <month>` for release titles for CCDL workshops.
+In [`AlexsLemonade/training-modules`](https://github.com/AlexsLemonade/training-modules), [create a new release](https://github.com/AlexsLemonade/training-modules/releases/new) that ties that material to this specific workshop. We use the convention `<year>-<month>` for tags and `<year> <month>` for release titles for Data Lab workshops.
 
 Don't forget to update the `_config.yaml` file in _this repository_ to point to the correct the release.

--- a/virtual-setup/README.md
+++ b/virtual-setup/README.md
@@ -1,8 +1,8 @@
 ---
-title: Setup for CCDL Virtual Workshops
+title: Setup for Data Lab Virtual Workshops
 ---
 
-The `virtual-setup` module houses instructions specifically for CCDL virtual training workshops.
+The `virtual-setup` module houses instructions specifically for Data Lab virtual training workshops.
 
 #### Table of Contents
 
@@ -12,4 +12,4 @@ The `virtual-setup` module houses instructions specifically for CCDL virtual tra
 * Set Up Instructions for Slack and Zoom
   * [Linux](linux-instructions.md)
   * [Mac](mac-instructions.md)
-  * [Windows](windows-instructions.md) 
+  * [Windows](windows-instructions.md)

--- a/virtual-setup/linux-instructions.md
+++ b/virtual-setup/linux-instructions.md
@@ -6,15 +6,18 @@ title: Linux Set Up Instructions for Virtual Workshops
 Our instructions generally follow the software provider's instructions, which we link below.
 For other Linux distros, please see the instructions from the software providers.*
 
-## Table of Contents
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**
 
-  - [Zoom](#zoom)
-    - [New Zoom Installation](#new-zoom-installation)
-    - [Set Up Preferences](#set-up-preferences)
-  - [Slack](#slack)
-    - [New Slack Installation](#new-slack-installation)
-    - [Logging in to the Cancer Data Science workspace](#logging-in-to-the-cancer-data-science-workspace)
+- [Zoom](#zoom)
+  - [New Zoom Installation](#new-zoom-installation)
+  - [Set Up Preferences](#set-up-preferences)
+- [Slack](#slack)
+  - [New Slack Installation](#new-slack-installation)
+  - [Logging in to the Cancer Data Science workspace](#logging-in-to-the-cancer-data-science-workspace)
 
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 ## Zoom
 
 ### New Zoom Installation
@@ -39,14 +42,14 @@ sudo apt install gdebi
 
 You will prompted for your admin password.
 
-Search your computer for GDebi and double click it. 
+Search your computer for GDebi and double click it.
 Open the Zoom DEB installer wih GDebi; you can use `Ctrl+O` and then open the Zoom `deb` file.
 
 Select `Install Package` to install Zoom.
 
 <img src = "screenshots/linux-zoom-gdebi-install.png" width = "450">
 
-To open Zoom, search your computer and double-click the icon to open it. 
+To open Zoom, search your computer and double-click the icon to open it.
 The following window will come up, which you can use to log in and set up preferences.
 
 <img src = "screenshots/linux-zoom-sign-in.png" width = "450">
@@ -69,7 +72,7 @@ Navigate to `Share Screen` preferences, uncheck `Enter full screen when a partic
 
 ### New Slack Installation
 
-If you do not already have Slack installed, you can download it at <https://slack.com/downloads/linux>. 
+If you do not already have Slack installed, you can download it at <https://slack.com/downloads/linux>.
 Depending on your distribution, download either the `deb` or `rpm` file.
 The following instructions are using the DEB installer on Ubuntu ([Instructions from Slack](https://slack.com/help/articles/212924728-Download-Slack-for-Linux--beta-)).
 

--- a/virtual-setup/mac-instructions.md
+++ b/virtual-setup/mac-instructions.md
@@ -2,15 +2,19 @@
 title: Mac Setup Instructions for Virtual Workshops
 ---
 
-## Table of Contents
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**
 
-  - [Zoom](#zoom)
-    - [New Zoom Installation](#new-zoom-installation)
-    - [Set Up Preferences](#set-up-preferences)
-    - [Screen sharing permissions](#screen-sharing-permissions)
-  - [Slack](#slack)
-    - [New Slack Installation](#new-slack-installation)
-    - [Logging in to the Cancer Data Science workspace](#logging-in-to-the-cancer-data-science-workspace)
+- [Zoom](#zoom)
+  - [New Zoom Installation](#new-zoom-installation)
+  - [Set Up Preferences](#set-up-preferences)
+  - [Screen sharing permissions](#screen-sharing-permissions)
+- [Slack](#slack)
+  - [New Slack Installation](#new-slack-installation)
+  - [Logging in to the Cancer Data Science workspace](#logging-in-to-the-cancer-data-science-workspace)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Zoom
 
@@ -82,7 +86,7 @@ If the Zoom Application does not appear in the list, click the "**+**" button  b
 
 <img src="screenshots/mac-zoom-12a-accessibility-select.png" alt="Accessibility selection" width="600">
 
-There is one more place where permissions will need to be given to Zoom to allow screen sharing, and that is the **Screen Recording** section of the same preferences pane.  
+There is one more place where permissions will need to be given to Zoom to allow screen sharing, and that is the **Screen Recording** section of the same preferences pane.
 
 <img src="screenshots/mac-zoom-13-recording-prefs.png" alt="Screen recording Preferences" width="600">
 

--- a/virtual-setup/slack-procedures.md
+++ b/virtual-setup/slack-procedures.md
@@ -1,5 +1,5 @@
 ---
-title: Using Slack for CCDL virtual workshops
+title: Using Slack for Data Lab virtual workshops
 ---
 
 
@@ -39,7 +39,7 @@ We have instructions for setting up Slack for your operating system available.
 
 Course instructors will add you to a private channel specific to your training a few days before the start of your training workshop.
 
-If you are not added to the training specific channel by 3 days prior to the start of training or are having trouble getting started with Slack, please [direct message](#using-direct-messages-during-training) a CCDL staff member (`Chante Bethell`, `Ally Hawkins`, `Jen O'Malley` or `Josh Shapiro`) in Cancer Data Science Slack or email [training@ccdatalab.org](mailto:training@ccdatalab.org).
+If you are not added to the training specific channel by 3 days prior to the start of training or are having trouble getting started with Slack, please [direct message](#using-direct-messages-during-training) a Data Lab staff member (`Chante Bethell`, `Ally Hawkins`, `Jen O'Malley`,  `Josh Shapiro`, or `Stephanie Spielman`) in Cancer Data Science Slack or email [training@ccdatalab.org](mailto:training@ccdatalab.org).
 
 ### Using the training-specific channel
 
@@ -102,13 +102,13 @@ You can not select a specific window to share.
 
 ### Using direct messages during training
 
-If you have a question that is **_highly specific_** to your own data or a problem with your RStudio credentials, you may [direct message](https://slack.com/help/articles/212281468-What-is-a-direct-message) a CCDL staff member.
+If you have a question that is **_highly specific_** to your own data or a problem with your RStudio credentials, you may [direct message](https://slack.com/help/articles/212281468-What-is-a-direct-message) a Data Lab staff member.
 
 First, use the new message button in the top right side corner of the Slack interface.
 
 <img src = "screenshots/slack-compose-new-message.png" width="300">
 
-You are then able to search for the CCDL instructors – `Chante Bethell`, `Ally Hawkins`, `Jen O'Malley` or `Josh Shapiro` – and compose your message.
+You are then able to search for the Data Lab instructors – `Chante Bethell`, `Ally Hawkins`, `Jen O'Malley`, `Josh Shapiro`, or `Stephanie Spielman` – and compose your message.
 
 Course instructors may direct you to the training-specific channel for more general questions or to another instructor where appropriate.
 

--- a/virtual-setup/slack-procedures.md
+++ b/virtual-setup/slack-procedures.md
@@ -18,7 +18,9 @@ We have instructions for setting up Slack for your operating system available.
 * [Mac](mac-instructions.md#slack)
 * [Windows](windows-instructions.md#slack)
 
-#### Table of Contents
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**
 
 - [How we use Slack during workshops](#how-we-use-slack-during-workshops)
   - [Using the training-specific channel](#using-the-training-specific-channel)
@@ -30,6 +32,8 @@ We have instructions for setting up Slack for your operating system available.
 - [General Slack use](#general-slack-use)
     - [Attaching a file or image](#attaching-a-file-or-image)
     - [Adding code blocks to messages](#adding-code-blocks-to-messages)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## How we use Slack during workshops
 

--- a/virtual-setup/windows-instructions.md
+++ b/virtual-setup/windows-instructions.md
@@ -6,11 +6,9 @@ title: Windows set up instructions for virtual workshops
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
-- [Windows set up instructions for virtual workshops](#windows-set-up-instructions-for-virtual-workshops)
-  - [Zoom Installation and Setup](#zoom-installation-and-setup)
-    - [New Installation](#new-installation)
-    - [Set Up Preferences](#set-up-preferences)
-  - [Slack](#slack)
+- [Zoom](#zoom)
+  - [Set Up Preferences](#set-up-preferences)
+- [Slack](#slack)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 

--- a/virtual-setup/windows-instructions.md
+++ b/virtual-setup/windows-instructions.md
@@ -1,5 +1,5 @@
 ---
-title: Windows set up instructions for virtual workshops
+title: Windows Setup Instructions for Virtual Workshops
 ---
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->

--- a/virtual-workshop/HOME.md
+++ b/virtual-workshop/HOME.md
@@ -40,10 +40,10 @@ Please take a look at our procedures to familiarize yourself with how we will be
 A description of our plans and goals for the workshop can be found on the [Workshop Structure document](workshop-structure.md). Please also refer to the [schedule](SCHEDULE.md) for information about timing and links relevant to each day.
 An overview of the modules we will cover and associated links can be found on the [Workshop Materials document](workshop-materials.md).
 
-During instruction sessions, CCDL staff will lead you through course material using [Zoom](../virtual-setup/zoom-procedures.md), [Slack](../virtual-setup/slack-procedures.md), and [RStudio Server](../virtual-setup/rstudio-login.md).
+During instruction sessions, Data Lab staff will lead you through course material using [Zoom](../virtual-setup/zoom-procedures.md), [Slack](../virtual-setup/slack-procedures.md), and [RStudio Server](../virtual-setup/rstudio-login.md).
 We will record instruction and provide it to workshop attendees so they can revisit it outside of workshop hours or in case they experience disruptions during live instruction.
 
-During [consultation sessions](resources-for-consultation-sessions.md), CCDL staff will be available to answer questions and provide 1:1 assistance as you work through exercise notebooks we provide or work with your own transcriptomic data.
+During [consultation sessions](resources-for-consultation-sessions.md), Data Lab staff will be available to answer questions and provide 1:1 assistance as you work through exercise notebooks we provide or work with your own transcriptomic data.
 We’ll use Zoom and Slack for these days, too.
 
 We recommend you follow these [guidelines for posting errors](posting-errors-guidelines.md) so you can maximize others' abilities to help you resolve your error.

--- a/virtual-workshop/resources-for-consultation-sessions.md
+++ b/virtual-workshop/resources-for-consultation-sessions.md
@@ -9,7 +9,9 @@ You can review instruction materials, work through exercise notebooks we provide
 
 On this page, we've assembled some resources you may find helpful during these sessions. For more information about the structure of consultation sessions and how to get help, please review [the Consultation sessions section of the Workshop Structure page](workshop-structure.md#consultation-sessions).
 
-**Table of contents**
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**
 
 - [Module cheatsheets](#module-cheatsheets)
 - [Working with your own data on RStudio Server](#working-with-your-own-data-on-rstudio-server)
@@ -28,6 +30,8 @@ On this page, we've assembled some resources you may find helpful during these s
   - [_Mus musculus_](#mus-musculus)
   - [_Danio rerio_](#danio-rerio)
   - [_Canis lupus familiaris_](#canis-lupus-familiaris)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Module cheatsheets
 

--- a/virtual-workshop/workshop-materials.md
+++ b/virtual-workshop/workshop-materials.md
@@ -5,7 +5,7 @@ nav_title: Materials
 
 ### Github Repositories
 
-CCDL training materials are available on Github, in either this repository or our shared [training-modules repository](https://github.com/AlexsLemonade/training-modules).
+Data Lab training materials are available on Github, in either this repository or our shared [training-modules repository](https://github.com/AlexsLemonade/training-modules).
 
 ### Slides
 

--- a/virtual-workshop/workshop-structure.md
+++ b/virtual-workshop/workshop-structure.md
@@ -46,7 +46,7 @@ You can read more about how we use Zoom and Slack in the [Zoom procedures](../vi
 | I need something clarified before we move on with instruction | [Use Zoom chat to message the meeting host with your question or use the `Raise Hand` button on Zoom](../virtual-setup/zoom-procedures.md#interacting-with-instructors-and-providing-feedback) |
 | I am stuck with an error message and am no longer able to follow the hands-on exercise | [Use Zoom chat](../virtual-setup/zoom-procedures.md#chat) to [message the meeting host and let them know you need 1:1 assistance](../virtual-setup/zoom-procedures.md#asking-for-11-help-during-instruction) - they will pair you with an available instructor in a [Zoom breakout room](../virtual-setup/zoom-procedures.md#joining-a-breakout-room) |
 | I have a general or conceptual question that can be addressed later in the lecture or asynchronously | Post in the [training-specific Slack channel](../virtual-setup/slack-procedures.md#using-the-training-specific-channel) |
-| I am having trouble with my login credentials | [Use Slack to direct message a CCDL staff member](../virtual-setup/slack-procedures.md#using-direct-messages-during-training) that is not leading instruction or the host of the Zoom meeting |
+| I am having trouble with my login credentials | [Use Slack to direct message a Data Lab staff member](../virtual-setup/slack-procedures.md#using-direct-messages-during-training) that is not leading instruction or the host of the Zoom meeting |
 | I am having technical difficulties that preclude me from using Zoom and Slack | Email [training@ccdatalab.org](mailto:training@ccdatalab.org) |
 
 ## Consultation sessions
@@ -74,7 +74,7 @@ We recommend following these [posting for error help guidelines](posting-errors-
 
 _Remember – if you have a question, another person in the course almost certainly has the same question!_
 
-<!--In addition, because the CCDL team is also currently all-remote, keeping most communication to the training-specific Slack channel allows us to better coordinate our efforts and make sure you get the support you need.-->
+<!--In addition, because the Data Lab team is also currently all-remote, keeping most communication to the training-specific Slack channel allows us to better coordinate our efforts and make sure you get the support you need.-->
 
 You can read more about how we use Zoom and Slack in the [Zoom procedures](../virtual-setup/zoom-procedures.md) and [Slack procedures](../virtual-setup/slack-procedures.md) documentation. We've put together the table below to serve as a guide at a glance.
 
@@ -84,8 +84,8 @@ You can read more about how we use Zoom and Slack in the [Zoom procedures](../vi
 | I have a question about an exercise notebook | Please use the [guidelines for posting for help](posting-errors-guidelines.md) and post in the [training-specific Slack channel](../virtual-setup/slack-procedures.md#using-the-training-specific-channel)|
 | I am having an issue that requires me to share my screen | Post in [the training-specific Slack channel](../virtual-setup/slack-procedures.md#using-the-training-specific-channel) - an instructor will initiate a Zoom meeting that you can [join from Slack](../virtual-setup/zoom-procedures.md#joining-a-zoom-call-from-slack) |
 | I would like to be paired up with other participants | Post in [the training-specific Slack channel](../virtual-setup/slack-procedures.md#using-the-training-specific-channel) |
-| I have a question that is **_highly specific_** to my data | [Use Slack to direct message a CCDL staff member](../virtual-setup/slack-procedures.md#using-direct-messages-during-training) |
-| I am having trouble with my login credentials | [Use Slack to direct message a CCDL staff member](../virtual-setup/slack-procedures.md#using-direct-messages-during-training) |
+| I have a question that is **_highly specific_** to my data | [Use Slack to direct message a Data Lab staff member](../virtual-setup/slack-procedures.md#using-direct-messages-during-training) |
+| I am having trouble with my login credentials | [Use Slack to direct message a Data Lab staff member](../virtual-setup/slack-procedures.md#using-direct-messages-during-training) |
 | I am having technical difficulties that preclude me from using Zoom and Slack | Email [training@ccdatalab.org](mailto:training@ccdatalab.org) |
 
 

--- a/virtual-workshop/workshop-structure.md
+++ b/virtual-workshop/workshop-structure.md
@@ -91,8 +91,8 @@ You can read more about how we use Zoom and Slack in the [Zoom procedures](../vi
 
 ## Presentations
 
-We will reconvene in a Zoom meeting on Friday at 2pm Eastern for presentations.
-You will give a short (5 minutes or less) presentation on what you worked on during the week to the rest of the group.
+We will reconvene in a Zoom meeting on Friday afternoon after the consultation session for presentations.
+You will be invited to give a short (5 minutes or less) presentation on what you worked on during the week to the rest of the group.
 This is meant to be a low-pressure opportunity to reflect on what you've learned!
 The content and format of the presentation is entirely up to you.
 Here are some examples of what people have presented in the past at our workshops:

--- a/working-with-your-data/working-with-your-own-data.md
+++ b/working-with-your-data/working-with-your-own-data.md
@@ -26,15 +26,15 @@ We will email you with a reminder 6 months from now so you can make sure to remo
 - [Things to know before uploading your data](#things-to-know-before-uploading-your-data)
 - [Load data that is online (from a url)](#load-data-that-is-online-from-a-url)
 - [Load data from an a ssh server](#load-data-from-an-a-ssh-server)
-- [Upload large files (> 1Gb) from your own computer](#upload-large-files--1gb-from-your-own-computer)
+- [Upload large files (\> 1Gb) from your own computer](#upload-large-files--1gb-from-your-own-computer)
   - [Install FileZilla on Mac](#install-filezilla-on-mac)
   - [Install FileZilla on Windows](#install-filezilla-on-windows)
   - [Install FileZilla on Ubuntu](#install-filezilla-on-ubuntu)
   - [Linking FileZilla to the RStudio Server](#linking-filezilla-to-the-rstudio-server)
   - [Using FileZilla to upload files to the RStudio Server](#using-filezilla-to-upload-files-to-the-rstudio-server)
   - [Using FileZilla to download files to your computer](#using-filezilla-to-download-files-to-your-computer)
-- [Upload *small* files (<1 Gb) from your own computer](#upload-small-files-1-gb-from-your-own-computer)
-- [Download *small* files (<1Gb) to your computer](#download-small-files-1gb-to-your-computer)
+- [Upload *small* files (\<1 Gb) from your own computer](#upload-small-files-1-gb-from-your-own-computer)
+- [Download *small* files (\<1Gb) to your computer](#download-small-files-1gb-to-your-computer)
 - [Installing packages](#installing-packages)
   - [Finding what packages are installed](#finding-what-packages-are-installed)
   - [Installing a new package](#installing-a-new-package)
@@ -76,15 +76,42 @@ wget https://www.ebi.ac.uk/arrayexpress/files/E-GEOD-67851/E-GEOD-67851.processe
 By default, the file will be saved to the current directory and the file name it had from its origin (so with the above example `E-GEOD-67851.processed.1.zip`).
 
 Likely you will want to be more specific about where you are saving the file to and what you are calling it.
-For that, we can use the `-O`, or `output` option with our `wget` command and specify a file path.  
+For that, we can use the `-O`, or `output` option with our `wget` command and specify a file path.
 
 *Template:*
 ```
 wget -O <FILE_PATH_TO_SAVE_TO> <URL>
 ```
 
-*Specific example:* Here's an example where we will download that same array express file, but instead save it to the `data` folder and call it `some_array_data.zip`.
+*Specific example: using the -O option* Here's another example an example where we will download that same array express file, but instead save it to a `data` folder and call it `some_array_data.zip`.
 (Best to keep the file extension consistent to avoid troubles!)
+
+
+Before we `wget` the files, we should create a `data/` folder to save to.
+Most often we will want to create this in a project-specific directory.
+[Keeping our files organized](https://www.thinkingondata.com/how-to-organize-data-science-projects/) can save us from some headaches in the future.
+
+
+Let's assume that we have already created a directory called `training_project` to hold all of my project files.
+That directory is in my home directory.
+
+```
+# Navigate to the project directory
+cd ~/training_project
+
+# List the folders and files of our current directory
+ls
+```
+
+If the `ls` command does not include `data` in its print out, it means we will need to make a `data` folder with the `mkdir` command.
+
+```
+# Make a new data folder
+mkdir data
+```
+
+You can double check that you successfully made a new folder by running `ls` again.
+Now we are ready to wget data and copy it to our `data/` folder.
 
 ```
 wget -O data/some_array_data.zip https://www.ebi.ac.uk/arrayexpress/files/E-GEOD-67851/E-GEOD-67851.processed.1.zip
@@ -245,7 +272,7 @@ After download is complete, you'll find the `FileZilla` `.exe` file in your down
 
 Double click on the file to install to begin installation.
 
-You'll be asked if you want to `Allow FileZilla to make changes` click `Yes`.  
+You'll be asked if you want to `Allow FileZilla to make changes` click `Yes`.
 
 There will be a series of steps (like below) you need to click `Next` and `Accept` to them.
 
@@ -271,10 +298,10 @@ At the top of the FileZilla screen, you can enter in the address and your creden
 <img src="screenshots/filezilla-bar.png">
 
 
-For `Host`, type in `rstudio.ccdatalab.org`.  
-For `Username`, type in the username you use to login in to our RStudio server.  
-For `Password` type in the password you use to login in to our RStudio server.  
-For `Port`, type in `22`.  
+For `Host`, type in `rstudio.ccdatalab.org`.
+For `Username`, type in the username you use to login in to our RStudio server.
+For `Password` type in the password you use to login in to our RStudio server.
+For `Port`, type in `22`.
 
 
 Then click the blue `Quickconnect` button.
@@ -347,7 +374,7 @@ A mini screen will pop up asking you to choose the file you want to upload:
 ![Choose file](screenshots/upload-choose-file.png)
 
 Choose your compressed data file, and click `OK`.
-This may take some time, particularly if you have a large dataset.  
+This may take some time, particularly if you have a large dataset.
 
 When the server is finished uploading your data, you should see your file in your `home` directory!
 It will automatically be uncompressed.
@@ -431,7 +458,7 @@ In this example, we'll install a package called `GenomicFeatures`.
 BiocManager::install("GenomicFeatures")
 ```
 
-You should get a similar successful installation message as in the previous section.  
+You should get a similar successful installation message as in the previous section.
 
 Or if it failed to install, it will give you a `non-zero exit status` message.
 

--- a/working-with-your-data/working-with-your-own-data.md
+++ b/working-with-your-data/working-with-your-own-data.md
@@ -10,14 +10,14 @@ This guide will take you through how to get your data onto our RStudio server so
 
 - If you are uploading data from human patient sequencing samples, **please be sure that you are doing so in a manner that is consistent with participant consent and your institution’s rules**. The only data that is permissible for upload to our server is that which has been summarized to non-sequence level and has no personally identifiable information (PII) and no protected health information (PHI).
 
-- Initially, we have equipped you with **50 GB of space** (if the data you would like to upload is larger than this, please consult one of the CCDL team members through Slack for assistance).
+- Initially, we have equipped you with **50 GB of space** (if the data you would like to upload is larger than this, please consult one of the Data Lab team members through Slack for assistance).
 
-- If you don't have your own data that you are looking to analyze, but would like real transcriptomic datasets to practice with, see the [Resources for Consultation Sessions page](../workshop/resources-for-consultation-sessions.md) and/or ask a CCDL team member for recommendations.
+- If you don't have your own data that you are looking to analyze, but would like real transcriptomic datasets to practice with, see the [Resources for Consultation Sessions page](../workshop/resources-for-consultation-sessions.md) and/or ask a Data Lab team member for recommendations.
 
 - You will have access to our RStudio Server for 6 months.
 We will email you with a reminder 6 months from now so you can make sure to remove any files from our RStudio Server that you may find useful before your access is revoked and the files are deleted.
 
-- As always, please Slack one of the CCDL team members if you need help with anything (that is what we are here for!).
+- As always, please Slack one of the Data Lab team members if you need help with anything (that is what we are here for!).
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
@@ -420,7 +420,7 @@ Note that the checkmarks in the `Packages` tab indicate which packages are loade
 
 Here we will take you through the most common R package installation steps and the most common roadblocks.
 However, [*package dependencies*](http://r-pkgs.had.co.nz/description.html#dependencies), packages needing other packages to work (and specific versions of them!), can make this a [hairy process](https://en.wikipedia.org/wiki/Dependency_hell).
-Because of this, we encourage you to reach out to one of the CCDL team members for assistance if you encounter problems beyond the scope of this brief introduction!
+Because of this, we encourage you to reach out to one of the Data Lab team members for assistance if you encounter problems beyond the scope of this brief introduction!
 
 #### install.packages()
 

--- a/working-with-your-data/working-with-your-own-data.md
+++ b/working-with-your-data/working-with-your-own-data.md
@@ -65,12 +65,14 @@ The most simple `wget` command just needs the URL to pull the file from.
 
 *Template:*
 ```
-wget <URL>
+wget '<URL>'
 ```
+
+The quote characters are not always required, but are a good practice in case the URL includes any strange characters that might cause problems.
 
 *Specific example:* Here's an example of us downloading a file from ArrayExpress
 ```
-wget https://www.ebi.ac.uk/arrayexpress/files/E-GEOD-67851/E-GEOD-67851.processed.1.zip
+wget 'https://www.ebi.ac.uk/arrayexpress/files/E-GEOD-67851/E-GEOD-67851.processed.1.zip'
 ```
 
 By default, the file will be saved to the current directory and the file name it had from its origin (so with the above example `E-GEOD-67851.processed.1.zip`).
@@ -80,7 +82,7 @@ For that, we can use the `-O`, or `output` option with our `wget` command and sp
 
 *Template:*
 ```
-wget -O <FILE_PATH_TO_SAVE_TO> <URL>
+wget -O <FILE_PATH_TO_SAVE_TO> '<URL>'
 ```
 
 *Specific example: using the -O option* Here's another example an example where we will download that same array express file, but instead save it to a `data` folder and call it `some_array_data.zip`.
@@ -114,7 +116,7 @@ You can double check that you successfully made a new folder by running `ls` aga
 Now we are ready to wget data and copy it to our `data/` folder.
 
 ```
-wget -O data/some_array_data.zip https://www.ebi.ac.uk/arrayexpress/files/E-GEOD-67851/E-GEOD-67851.processed.1.zip
+wget -O data/some_array_data.zip 'https://www.ebi.ac.uk/arrayexpress/files/E-GEOD-67851/E-GEOD-67851.processed.1.zip'
 ```
 
 `-O` is one of many `wget` command options.
@@ -146,7 +148,7 @@ You can still use `wget` to obtain data if you need credentials.
 We don't recommend you put your password or any other credentials in the script or enter your password as part of a command, so you will want to type the following directly into the Terminal:
 
 ```
-wget --user=<USERNAME> --ask-password <URL>
+wget --user=<USERNAME> --ask-password '<URL>'
 ```
 Using the `--ask-password` will prompt you to enter your password.
 

--- a/working-with-your-data/working-with-your-own-data.md
+++ b/working-with-your-data/working-with-your-own-data.md
@@ -85,7 +85,7 @@ For that, we can use the `-O`, or `output` option with our `wget` command and sp
 wget -O <FILE_PATH_TO_SAVE_TO> '<URL>'
 ```
 
-*Specific example: using the -O option* Here's another example an example where we will download that same array express file, but instead save it to a `data` folder and call it `some_array_data.zip`.
+*Specific example: using the -O option* Here's another example where we will download that same array express file, but instead save it to a `data` folder and call it `some_array_data.zip`.
 (Best to keep the file extension consistent to avoid troubles!)
 
 


### PR DESCRIPTION
Before creating the website for March 2023, I thought I would clean up a few things. 

A short list of cleanup things I did here:
- Update TOCs: closes #98
- Update Window title: closes #95
- Changed "CCDL" to "Data Lab" across many but not all pages, partially addressing #92
- Made presentation time generic: closes #85
- incorporated updates to working with your own data: closes #34


