### PR TITLE
Add GHA to copy completed notebooks

### DIFF
--- a/.github/workflows/copy-completed-notebooks.yml
+++ b/.github/workflows/copy-completed-notebooks.yml
@@ -42,11 +42,8 @@ jobs:
 
       - name: Configure git
         run: |
-          # Configure git for just the `website` repo local credentials
-          cd website
-          git config --local user.email "actions@github.com"
-          git config --local user.name "GitHub Actions"
-          cd ..
+          git config --global user.email "actions@github.com"
+          git config --global user.name "GitHub Actions"
 
       - name: Copy HTML completed notebooks from training-modules
         shell: bash

--- a/.github/workflows/copy-completed-notebooks.yml
+++ b/.github/workflows/copy-completed-notebooks.yml
@@ -74,13 +74,13 @@ jobs:
               ;;
 
             "Bulk RNA-seq")
-              modules=("RNA-seq")
+              modules=("intro-to-R-tidyverse", "RNA-seq")
               ;;
           esac
 
           # Copy all completed notebooks from the given directories
           for module in ${modules[@]}; do
-            cp training-modules/${module}/[0-9]*.html ${target_path}
+            cp training-modules/${module}/[0-9]*.html ${target_path}/${module}
           done
 
       - name: Create PR with rendered notebooks

--- a/.github/workflows/copy-completed-notebooks.yml
+++ b/.github/workflows/copy-completed-notebooks.yml
@@ -55,28 +55,33 @@ jobs:
           #  Advanced scRNA-seq: advanced-scRNA-seq/
           #  bulk RNA-seq: RNA-seq/
 
+          # Path to copy notebooks to
           target_path=website/completed-notebooks/
 
-          # Copy notebooks over depending on which training module is being taught
+          # Create array of directories from which notebooks should be copied
           case "${{ github.event.inputs.training-module }}" in
 
             "Introduction to R and Tidyverse")
-              cp training-modules/intro-to-R-tidyverse/[0-9]*.html ${target_path}
+              modules=("intro-to-R-tidyverse")
               ;;
 
             "Introduction to single-cell RNA-seq")
-              cp training-modules/intro-to-R-tidyverse/[0-9]*.html ${target_path}
-              cp training-modules/scRNA-seq/[0-9]*.html ${target_path}
+              modules=("intro-to-R-tidyverse" "scRNA-seq")
               ;;
 
             "Advanced single-cell RNA-seq")
-              cp training-modules/scRNA-seq-advanced/[0-9]*.html ${target_path}
+              modules=("scRNA-seq-advanced")
               ;;
 
             "Bulk RNA-seq")
-              cp training-modules/RNA-seq/[0-9]*.html ${target_path}
+              modules=("RNA-seq")
               ;;
           esac
+
+          # Copy all completed notebooks from the given directories
+          for module in ${modules[@]}; do
+            cp training-modules/${module}/[0-9]*.html ${target_path}
+          done
 
       - name: Create PR with rendered notebooks
         uses: peter-evans/create-pull-request@v5

--- a/.github/workflows/copy-completed-notebooks.yml
+++ b/.github/workflows/copy-completed-notebooks.yml
@@ -15,6 +15,7 @@ on:
           - "Introduction to R and Tidyverse"
           - "Introduction to single-cell RNA-seq"
           - "Advanced single-cell RNA-seq"
+          - "Bulk RNA-seq"
         required: true
       training-modules-tag:
         type: string
@@ -37,16 +38,17 @@ jobs:
       - name: Checkout this repository
         uses: actions/checkout@v3
         with:
-          path: main
+          path: website
 
       - name: Configure git
         run: |
-          # use global flag since we have multiple repos here
-          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
-          git config --global user.email "actions@github.com"
-          git config --global user.name "GitHub Actions"
+          # Configure git for just the `website` repo local credentials
+          cd website
+          git config --local user.email "actions@github.com"
+          git config --local user.name "GitHub Actions"
+          cd ..
 
-      - name: Get HTML completed notebooks from training-modules
+      - name: Copy HTML completed notebooks from training-modules
         shell: bash
         run: |
           # The completed notebooks to copy will depend on which workshop module this is.
@@ -54,48 +56,36 @@ jobs:
           #  Intro R: intro_to_R_tidyverse/
           #  Intro scRNA-seq: intro_to_R_tidyverse/ and scRNA-seq/
           #  Advanced scRNA-seq: advanced-scRNA-seq/
+          #  bulk RNA-seq: RNA-seq/
 
-          # the url for for this tag of the training-modules repo where files will be downloaded from
-          base_url=https://raw.githubusercontent.com/AlexsLemonade/training-modules/${{ github.event.inputs.training-modules-tag }}
+          target_path=website/completed-notebooks/
 
-          ########### Get paths for files to copy, for the given module ############
+          # Copy notebooks over depending on which training module is being taught
+          case "${{ github.event.inputs.training-module }}" in
 
-          # We have to cd into training-modules to ensure correct paths come out of `ls`
-          cd training-modules
+            "Introduction to R and Tidyverse")
+              cp training-modules/intro-to-R-tidyverse/[0-9]*.html ${target_path}
+              ;;
 
-          # First, intro-to-R-tidyverse notebooks for the intro R workshop
-          if [[ "${{ github.event.inputs.training-module }}" == "Introduction to R and Tidyverse" ]]; then
-            notebook_files=`ls intro-to-R-tidyverse/*html`
-          fi
+            "Introduction to single-cell RNA-seq")
+              cp training-modules/intro-to-R-tidyverse/[0-9]*.html ${target_path}
+              cp training-modules/scRNA-seq/[0-9]*.html ${target_path}
+              ;;
 
-          # Second, intro-to-R-tidyverse notebooks and scRNA-seq notebooks for the intro scRNA-seq workshop
-          if [[ "${{ github.event.inputs.training-module }}" == "Introduction to single-cell RNA-seq" ]]; then
-            notebook_files=`ls intro-to-R-tidyverse/*html scRNA-seq/*html`
-          fi
+            "Advanced single-cell RNA-seq")
+              cp training-modules/scRNA-seq-advanced/[0-9]*.html ${target_path}
+              ;;
 
-          # Third, scRNA-seq-advanced notebooks for the advanced scRNA-seq workshop
-          if [[ "${{ github.event.inputs.training-module }}" == "Advanced single-cell RNA-seq" ]]; then
-            notebook_files=`ls scRNA-seq-advanced/*html`
-          fi
-
-          # Now, we have to navigate back to the completed-notebooks directory
-          cd ../main/completed-notebooks
-
-          # curl completed notebook htmls into main/completed-notebooks
-          for path in ${notebook_files}
-          do
-            # test that the path is to an .html file, error if not
-            # note that at least one notebook is only .html, NOT .nb.html, so we'll just use .html
-            [[ $path != *.html ]] && echo "'$path' is not an .html file." && exit 1
-            echo ${base_url}/${path}
-            curl --fail -sO ${base_url}/${path}
-          done
+            "Bulk RNA-seq")
+              cp training-modules/RNA-seq/[0-9]*.html ${target_path}
+              ;;
+          esac
 
       - name: Create PR with rendered notebooks
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v5
         id: cpr
         with:
-          path: main # must be a RELATIVE path to _this_ repo
+          path: website # must be a RELATIVE path to _this_ repo
           commit-message: Copy completed notebooks from training-modules@${{ github.event.inputs.training-modules-tag }}
           signoff: false
           branch: auto_copy_completed_notebooks
@@ -104,7 +94,7 @@ jobs:
           body: |
             ### Description:
             This PR was auto-generated from github actions
-              - Copy completed HTML notebooks from training-modules repository, tag ${{ github.event.inputs.training-modules-tag }}
+              - Copy completed notebooks for the "${{ github.event.inputs.training-module }}" module from the `training-modules` repository, tag `${{ github.event.inputs.training-modules-tag }}`
           labels: |
             automated
           reviewers: $GITHUB_ACTOR

--- a/.github/workflows/copy-completed-notebooks.yml
+++ b/.github/workflows/copy-completed-notebooks.yml
@@ -1,0 +1,117 @@
+name: Copy completed HTML notebooks to training website repository
+# Copy completed HTML notebooks from the training-modules repo to this repo
+# This action will open a pull request containing completed HTML notebooks
+
+# This is a manually triggered workflow that takes two inputs:
+#  # The name of the workshop being taught
+#  # The training-modules repo tag to copy notebooks from
+on:
+  workflow_dispatch:
+    inputs:
+      training-module:
+        type: choice
+        description: Use the dropdown menu to select which training workshop module this website is being created for.
+        options:
+          - "Introduction to R and Tidyverse"
+          - "Introduction to single-cell RNA-seq"
+          - "Advanced single-cell RNA-seq"
+        required: true
+      training-modules-tag:
+        type: string
+        description: The `training-modules` repo tag to copy completed notebooks from, e.g. 2023-june
+        default: "master"
+        required: true
+
+jobs:
+  file-completed-notebooks-pr:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout training-modules repository
+        uses: actions/checkout@v3
+        with:
+          repository: AlexsLemonade/training-modules
+          ref: ${{ github.event.inputs.training-modules-tag }}
+          path: training-modules
+
+      - name: Checkout this repository
+        uses: actions/checkout@v3
+        with:
+          path: main
+
+      - name: Configure git
+        run: |
+          # use global flag since we have multiple repos here
+          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
+          git config --global user.email "actions@github.com"
+          git config --global user.name "GitHub Actions"
+
+      - name: Get HTML completed notebooks from training-modules
+        shell: bash
+        run: |
+          # The completed notebooks to copy will depend on which workshop module this is.
+          # For each module, the directory of notebooks to copy are:
+          #  Intro R: intro_to_R_tidyverse/
+          #  Intro scRNA-seq: intro_to_R_tidyverse/ and scRNA-seq/
+          #  Advanced scRNA-seq: advanced-scRNA-seq/
+
+          # the url for for this tag of the training-modules repo where files will be downloaded from
+          base_url=https://raw.githubusercontent.com/AlexsLemonade/training-modules/${{ github.event.inputs.training-modules-tag }}
+
+          ########### Get paths for files to copy, for the given module ############
+
+          # We have to cd into training-modules to ensure correct paths come out of `ls`
+          cd training-modules
+
+          # First, intro-to-R-tidyverse notebooks for the intro R workshop
+          if [[ "${{ github.event.inputs.training-module }}" == "Introduction to R and Tidyverse" ]]; then
+            notebook_files=`ls intro-to-R-tidyverse/*html`
+          fi
+
+          # Second, intro-to-R-tidyverse notebooks and scRNA-seq notebooks for the intro scRNA-seq workshop
+          if [[ "${{ github.event.inputs.training-module }}" == "Introduction to single-cell RNA-seq" ]]; then
+            notebook_files=`ls intro-to-R-tidyverse/*html scRNA-seq/*html`
+          fi
+
+          # Third, scRNA-seq-advanced notebooks for the advanced scRNA-seq workshop
+          if [[ "${{ github.event.inputs.training-module }}" == "Advanced single-cell RNA-seq" ]]; then
+            notebook_files=`ls scRNA-seq-advanced/*html`
+          fi
+
+          # Now, we have to navigate back to the completed-notebooks directory
+          cd ../main/completed-notebooks
+
+          # curl completed notebook htmls into main/completed-notebooks
+          for path in ${notebook_files}
+          do
+            # test that the path is to an .html file, error if not
+            # note that at least one notebook is only .html, NOT .nb.html, so we'll just use .html
+            [[ $path != *.html ]] && echo "'$path' is not an .html file." && exit 1
+            echo ${base_url}/${path}
+            curl --fail -sO ${base_url}/${path}
+          done
+
+      - name: Create PR with rendered notebooks
+        uses: peter-evans/create-pull-request@v4
+        id: cpr
+        with:
+          path: main # must be a RELATIVE path to _this_ repo
+          commit-message: Copy completed notebooks from training-modules@${{ github.event.inputs.training-modules-tag }}
+          signoff: false
+          branch: auto_copy_completed_notebooks
+          delete-branch: true
+          title: 'GHA: Automated transfer of completed notebooks'
+          body: |
+            ### Description:
+            This PR was auto-generated from github actions
+              - Copy completed HTML notebooks from training-modules repository, tag ${{ github.event.inputs.training-modules-tag }}
+          labels: |
+            automated
+          reviewers: $GITHUB_ACTOR
+
+
+      # Write out PR info
+      - name: Check outputs
+        run: |
+          echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
+          echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"


### PR DESCRIPTION
**⚠️ Stacked on #129**
Closes #111

This PR adds a github action that will copy completed notebooks from a given tag of `training-modules` into this template repository (presumably after someone has copied the template!). All repos involved are public, so no special security things here, which is important since we might expect folks running external workshops to use this action.

I developed this workflow in one of my personal repositories so I could spam myself to my heart's content, hence only one commit here. I confirmed it worked for any of the three workshops, but we should still do a final.final round of testing here as well. I figure we may want to get any conceptual reviews implemented first though, so this action currently only runs manually. Once we're confident that this is how the GHA should actually look, I can add a PR target so it will run here.

I made a variety of choices along the way which we can discuss during review if there are strongly differing opinions. Here's what I did!

- The workflow takes _two_ inputs, and the first one is conveniently handled with a dropdown menu:
  - Which training module is being taught (this dictates which files to copy over). This defaults to the first choice item, which is a plain intro R workshop.
    - Note that I did not include bulk rnaseq here, but I can! I figured we are unlikely to teach it again, but that said there's nothing preventing external people from running one and it's a quick change to add in.
  - The `training-modules` repo tag of interest, which defaults to `master`.
- The workflow then clones _both_ repos: `training-modules` and this one. You have to be a little careful with paths here, but it seems to work ok! I opted for this approach to find the files to copy rather than maintaining something analogous to an `exercise_list` like we do for the exercise copying action. 
  - Note that this repo gets cloned into a directory called `main`, which seemed like a good generic name for the repo we are PRing into (it won't always be `training-specific-template`, since this action will generally be run in a differently-named repo created from this template).
  - I decided this for two reasons: I'd rather keep this all in 1 repo, and also it seemed like a fun thing to try out.
- Since there are two repos here, I had to use `--global` flags for all the `git config` settings.
  - If we don't want global username and email, I could alternatively `cd main` and then set local username/email if that is preferred. 
- Then, the workflow will make some arrays of which files need to be copied, and then they get curled into `completed-notebooks/`
  - Noting here that I originally looked for `.nb.html` files, but we have one `.html` (not a notebook) living in intro scRNA-seq, so I went more permissive to just `.html`.
- Finally, file the PR! 

One key question for reviewers: Would we rather see the bash code pulled out into it's own script to live in `scripts/`? I was on the fence at the beginning, but now I'm trending towards "yes".