### PR TITLE
Update GHA issues

### DIFF
--- a/.github/workflows/file-setup-issues.yml
+++ b/.github/workflows/file-setup-issues.yml
@@ -69,6 +69,14 @@ jobs:
           content-filepath: ./setup-issue-templates/workshop-release.md
           labels: automated training issue
 
+      # Issue for copying completed notebooks from training-modules
+      - name: Create issue for copying completed notebooks
+        uses: peter-evans/create-issue-from-file@v4.0.0
+        with:
+          title: Create ${{ github.event.inputs.tag }} release of training-modules
+          content-filepath: ./setup-issue-templates/copy-completed-notebooks.md
+          labels: automated training issue, blocked
+
       # Issue for creating a final version of schedule
       - name: Create final schedule issue
         uses: peter-evans/create-issue-from-file@v4.0.0

--- a/.github/workflows/file-setup-issues.yml
+++ b/.github/workflows/file-setup-issues.yml
@@ -11,16 +11,16 @@ on:
         required: true
 
 jobs:
-  # This runs a single job that creates issues from files 
+  # This runs a single job that creates issues from files
   createIssuesFromFile:
     runs-on: ubuntu-latest
-    
+
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
 
-      # Check out  
+      # Check out
       - uses: actions/checkout@v3
-      
+
       # Issue for turning on GitHub pages
       - name: Create GitHub Pages issue
         uses: peter-evans/create-issue-from-file@v4.0.0
@@ -28,7 +28,7 @@ jobs:
           title: Turn on GitHub Pages
           content-filepath: ./setup-issue-templates/gh-pages.md
           labels: automated training issue
-      
+
       # Issue for turning on branch protection
       - name: Create branch protection issue
         uses: peter-evans/create-issue-from-file@v4.0.0
@@ -37,22 +37,14 @@ jobs:
           content-filepath: ./setup-issue-templates/branch-protection.md
           labels: automated training issue
 
-      # Issue for deleting and renaming directories
-      - name: Create issue for deleting irrelevant folders
-        uses: peter-evans/create-issue-from-file@v4.0.0
-        with:
-          title: Delete irrelevant workshop directories and rename
-          content-filepath: ./setup-issue-templates/delete-directories-and-rename.md
-          labels: automated training issue
-      
       # Issue updating `_config.yaml`
       - name: Create issue for _config.yaml
         uses: peter-evans/create-issue-from-file@v4.0.0
         with:
           title: Update _config.yaml to use values relevant to this workshop
           content-filepath: ./setup-issue-templates/update-config.md
-          labels: automated training issue   
-           
+          labels: automated training issue
+
       # Issue for header pages
       - name: Create issue for setting up header pages
         uses: peter-evans/create-issue-from-file@v4.0.0
@@ -60,7 +52,7 @@ jobs:
           title: Update the pages that will appear in the header
           content-filepath: ./setup-issue-templates/update-header-pages.md
           labels: automated training issue
-      
+
       # Issue for adding PDF versions of slides
       - name: Create issue for slides
         uses: peter-evans/create-issue-from-file@v4.0.0
@@ -84,7 +76,7 @@ jobs:
           title: Create ${{ github.event.inputs.tag }} release of training-modules
           content-filepath: ./setup-issue-templates/workshop-release.md
           labels: automated training issue
-      
+
       # Issue for creating a final version of schedule
       - name: Create final schedule issue
         uses: peter-evans/create-issue-from-file@v4.0.0

--- a/.github/workflows/file-setup-issues.yml
+++ b/.github/workflows/file-setup-issues.yml
@@ -45,14 +45,6 @@ jobs:
           content-filepath: ./setup-issue-templates/update-config.md
           labels: automated training issue
 
-      # Issue for header pages
-      - name: Create issue for setting up header pages
-        uses: peter-evans/create-issue-from-file@v4.0.0
-        with:
-          title: Update the pages that will appear in the header
-          content-filepath: ./setup-issue-templates/update-header-pages.md
-          labels: automated training issue
-
       # Issue for adding PDF versions of slides
       - name: Create issue for slides
         uses: peter-evans/create-issue-from-file@v4.0.0

--- a/.github/workflows/file-setup-issues.yml
+++ b/.github/workflows/file-setup-issues.yml
@@ -84,11 +84,3 @@ jobs:
           title: Update README to be user-facing (remove instructions)
           content-filepath: ./setup-issue-templates/user-facing-readme.md
           labels: automated training issue
-
-      # Issue for updating course website to reflect workshop's content
-      - name: Create issue for revising workshop content
-        uses: peter-evans/create-issue-from-file@v4.0.0
-        with:
-          title: Ensure that descriptions of and links to workshop content are up-to-date
-          content-filepath: ./setup-issue-templates/tailor-to-workshop-content.md
-          labels: automated training issue

--- a/.github/workflows/file-setup-issues.yml
+++ b/.github/workflows/file-setup-issues.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Create issue for copying completed notebooks
         uses: peter-evans/create-issue-from-file@v4.0.0
         with:
-          title: Create ${{ github.event.inputs.tag }} release of training-modules
+          title: Copy completed notebooks to training website
           content-filepath: ./setup-issue-templates/copy-completed-notebooks.md
           labels: automated training issue, blocked
 

--- a/components/dictionary.txt
+++ b/components/dictionary.txt
@@ -49,6 +49,7 @@ FileZilla's
 forloop
 Gb
 GDebi
+GHA
 GRCh
 GRCm
 GRCz

--- a/components/dictionary.txt
+++ b/components/dictionary.txt
@@ -49,7 +49,6 @@ FileZilla's
 forloop
 Gb
 GDebi
-GHA
 GRCh
 GRCm
 GRCz

--- a/setup-issue-templates/copy-completed-notebooks.md
+++ b/setup-issue-templates/copy-completed-notebooks.md
@@ -1,5 +1,5 @@
-Add completed notebooks to the `completed-notebooks` directory by manually running the GitHub Action (GHA)`copy-completed-notebooks.yml`.
-This GHA requires two input arguments that you will be prompted to provide:
+Add completed notebooks to the `completed-notebooks` directory by manually running the GitHub Action `copy-completed-notebooks.yml`.
+This action requires two input arguments that you will be prompted to provide:
 
 - Which training module is being taught
 - The [`training-modules` repository](https://github.com/AlexsLemonade/training-modules) tag from which notebooks should be copied

--- a/setup-issue-templates/copy-completed-notebooks.md
+++ b/setup-issue-templates/copy-completed-notebooks.md
@@ -1,0 +1,9 @@
+Add completed notebooks to the `completed-notebooks` directory by manually running the GitHub Action (GHA)`copy-completed-notebooks.yml`.
+This GHA requires two input arguments that you will be prompted to provide:
+
+- Which training module is being taught
+- The [`training-modules` repository](https://github.com/AlexsLemonade/training-modules) tag from which notebooks should be copied
+
+_Optional_: You can also remove the `.gitkeep` file from `completed-notebooks`.
+
+

--- a/setup-issue-templates/delete-directories-and-rename.md
+++ b/setup-issue-templates/delete-directories-and-rename.md
@@ -1,7 +1,0 @@
-- [ ] Delete the irrelevant `*-workshop` folder. 
-If your workshop is a virtual workshop, remove the `in-person-workshop` folder. 
-If your workshop is an in-person workshop, remove the `virtual-workshop` folder.
-	- If you're running an in-person workshop, you will not need the `virtual-setup` folder, either.
-- [ ] Rename the relevant `*-workshop` folder to `workshop`. 
-For a virtual workshop, `virtual-workshop` should be renamed to `workshop`.
-Changing this folder name will make several links in the repository work –there are instances where we link to a schedule with `../workshop/SCHEDULE.md`, for example.

--- a/setup-issue-templates/tailor-to-workshop-content.md
+++ b/setup-issue-templates/tailor-to-workshop-content.md
@@ -1,6 +1,0 @@
-Revise the course website to reflect the content this workshop will be covering. 
-
-For virtual workshops, the areas that need to be updated are:
-
-* The first bulletpoint in `virtual-workshop/workshop-structure.md` (which becomes `workshop/workshop-structure.md`)
-* The modules we link to in `virtual-workshop/workshop-materials.md` (which becomes `workshop/workshop-materials.md`)

--- a/setup-issue-templates/update-config.md
+++ b/setup-issue-templates/update-config.md
@@ -1,1 +1,12 @@
-Update `_config.yaml` to use values that are relevant for your workshop such as the Docker repository and tag that you will be using for the workshop. [We use jekyll variable substitution as part of this template](https://jekyllrb.com/docs/includes/#passing-parameter-variables-to-includes).
+Update `_config.yaml` to use values that are relevant for your workshop. [We use jekyll variable substitution as part of this template](https://jekyllrb.com/docs/includes/#passing-parameter-variables-to-includes).
+
+The following variables **must** be updated according the format specified in `_config.yaml`:
+
+- [ ] `training_title`
+- [ ] `start_date`
+- [ ] `end_date`
+- [ ] `workshop_type`
+- [ ] `worshop_content`
+- [ ] `instructors`
+- [ ] `docker_repo`
+- [ ] `docker_tag`

--- a/setup-issue-templates/update-header-pages.md
+++ b/setup-issue-templates/update-header-pages.md
@@ -1,1 +1,0 @@
-Update the pages that will appear in the header (`header_pages:`) in `_config.yaml`. Any page that appears in the header should have a navigation title (`nav_title:`) in its YAML header.

--- a/workshop/workshop-logistics.md
+++ b/workshop/workshop-logistics.md
@@ -12,23 +12,20 @@ nav_title: Logistics
     {% include_relative participant-information.md %}
 {% endif %}
 
-<!-- Define workshop content based on `site.workshop_content` -->
-
-{% case site.workshop_content  %}
-{% when "intro-r" %}
-  {% assign workshop_content = "the R programming language" %}
-{% when "intro-single-cell" %}
-  {% assign workshop_content = "the R programming language and the fundamentals of scRNA-seq analysis" %}
-{% when "intro-bulk" %}
-  {% assign workshop_content = "the R programming language and the fundamentals of bulk RNA-seq analysis" %}
-{% when "advanced-single-cell" %}
-  {% assign workshop_content = "advanced scRNA-seq analyses" %}
-{% endcase %}
 ## Workshop Structure
 
 Our goals for the workshop include the following:
 
-* You will be introduced to {{ workshop_content }} through a series of hands-on, interactive lessons.
+* You will be introduced to {%- case site.workshop_content -%}
+{% when "intro-r" %}
+  the R programming language
+{% when "intro-single-cell" %}
+  the R programming language and the fundamentals of scRNA-seq analysis
+{% when "intro-bulk" %}
+  the R programming language and the fundamentals of bulk RNA-seq analysis
+{% when "advanced-single-cell" %}
+  advanced scRNA-seq analyses
+{%- endcase -%} through a series of hands-on, interactive lessons.
 * You are able to ask questions and receive 1:1 assistance as needed during instruction. Because our instruction is almost entirely through hands-on lessons, we want to make sure we can help you through any difficulties or errors you may encounter.
 * You have the opportunity to practice the skills you learn during instruction in consultation sessions with the support of your instructors, and/or using exercise notebooks we have provided.
 * You receive consultation about the data you are working with to answer your research questions.

--- a/workshop/workshop-logistics.md
+++ b/workshop/workshop-logistics.md
@@ -17,7 +17,7 @@ nav_title: Logistics
 Our goals for the workshop include the following:
 
 * You will be introduced to
-{% case workshop_content %}
+{% case site.workshop_content %}
 {%- when "intro-r" -%}
  the R programming language
 {%- when "intro-single-cell" -%}

--- a/workshop/workshop-logistics.md
+++ b/workshop/workshop-logistics.md
@@ -12,11 +12,23 @@ nav_title: Logistics
     {% include_relative participant-information.md %}
 {% endif %}
 
+<!-- Define workshop content based on `site.workshop_content` -->
+
+{% case site.workshop_content  %}
+{% when "intro-r" %}
+  {% assign workshop_content = "the R programming language" %}
+{% when "intro-single-cell" %}
+  {% assign workshop_content = "the R programming language and the fundamentals of scRNA-seq analysis" %}
+{% when "intro-bulk" %}
+  {% assign workshop_content = "the R programming language and the fundamentals of bulk RNA-seq analysis" %}
+{% when "advanced-single-cell" %}
+  {% assign workshop_content = "advanced scRNA-seq analyses" %}
+{% endcase %}
 ## Workshop Structure
 
 Our goals for the workshop include the following:
 
-* You will be introduced to `<workshop content>` through a series of hands-on, interactive lessons.
+* You will be introduced to {{ workshop_content }} through a series of hands-on, interactive lessons.
 * You are able to ask questions and receive 1:1 assistance as needed during instruction. Because our instruction is almost entirely through hands-on lessons, we want to make sure we can help you through any difficulties or errors you may encounter.
 * You have the opportunity to practice the skills you learn during instruction in consultation sessions with the support of your instructors, and/or using exercise notebooks we have provided.
 * You receive consultation about the data you are working with to answer your research questions.

--- a/workshop/workshop-logistics.md
+++ b/workshop/workshop-logistics.md
@@ -25,8 +25,7 @@ Our goals for the workshop include the following:
 {%- when "intro-bulk" -%}
   the R programming language and the fundamentals of bulk RNA-seq analysis
 {%- when "advanced-single-cell" -%}
-  advanced scRNA-seq analyses
-{% endcase %}
+  advanced scRNA-seq analyses {% endcase %}
 through a series of hands-on, interactive lessons.
 * You are able to ask questions and receive 1:1 assistance as needed during instruction. Because our instruction is almost entirely through hands-on lessons, we want to make sure we can help you through any difficulties or errors you may encounter.
 * You have the opportunity to practice the skills you learn during instruction in consultation sessions with the support of your instructors, and/or using exercise notebooks we have provided.

--- a/workshop/workshop-logistics.md
+++ b/workshop/workshop-logistics.md
@@ -16,16 +16,18 @@ nav_title: Logistics
 
 Our goals for the workshop include the following:
 
-* You will be introduced to {%- case site.workshop_content -%}
-{% when "intro-r" %}
-  the R programming language
-{% when "intro-single-cell" %}
+* You will be introduced to
+{% case workshop_content %}
+{%- when "intro-r" -%}
+ the R programming language
+{%- when "intro-single-cell" -%}
   the R programming language and the fundamentals of scRNA-seq analysis
-{% when "intro-bulk" %}
+{%- when "intro-bulk" -%}
   the R programming language and the fundamentals of bulk RNA-seq analysis
-{% when "advanced-single-cell" %}
+{%- when "advanced-single-cell" -%}
   advanced scRNA-seq analyses
-{%- endcase -%} through a series of hands-on, interactive lessons.
+{% endcase %}
+through a series of hands-on, interactive lessons.
 * You are able to ask questions and receive 1:1 assistance as needed during instruction. Because our instruction is almost entirely through hands-on lessons, we want to make sure we can help you through any difficulties or errors you may encounter.
 * You have the opportunity to practice the skills you learn during instruction in consultation sessions with the support of your instructors, and/or using exercise notebooks we have provided.
 * You receive consultation about the data you are working with to answer your research questions.


### PR DESCRIPTION
Closes #124 

This PR updates the automated issues that are filed via GHA, as follows:

- Delete deprecated issues:
  - `setup-issue-templates/delete-directories-and-rename.md`
  - `setup-issue-templates/update-header-pages.md`
  - `setup-issue-templates/tailor-to-workshop-content.md`
    - I was able to deprecate this issue in this PR by adding case/switch to `workshop/workshop-logistics.md` for a quick string about workshop content, using the new config variable `site.workshop_content`.

- Update existing issues:
  - `setup-issue-templates/update-config.md`

- Add new issue:
  - `setup-issue-templates/copy-completed-notebooks.md`

Note that `htmlpreview` [was already removed](https://github.com/AlexsLemonade/training-specific-template/commit/88700f33a8234ee7aa8d67ec2045ae2ed051d8d2#diff-6cf1279f7687011c8a66b7e82bfa19fd9b76814123294f82cfeba4efb0a1b24f) from `setup-issue-templates/draft-schedule.md` & `setup-issue-templates/final-schedule.md`, so no further changes to those in this PR.


Reviewers, let me know if anything could use more or less detail!