### PR TITLE
Update README instructions

### DIFF
--- a/.github/workflows/file-setup-issues.yml
+++ b/.github/workflows/file-setup-issues.yml
@@ -5,10 +5,6 @@ name: Manually trigger issue creation for standard set up
 # https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow#running-a-workflow-on-github
 on:
   workflow_dispatch:
-    inputs:
-      tag:
-        description: training-modules release tag for training workshop
-        required: true
 
 jobs:
   # This runs a single job that creates issues from files
@@ -65,7 +61,7 @@ jobs:
       - name: Create issue for training-specific release
         uses: peter-evans/create-issue-from-file@v4.0.0
         with:
-          title: Create ${{ github.event.inputs.tag }} release of training-modules
+          title: Create release of training-modules to associate with this workshop
           content-filepath: ./setup-issue-templates/workshop-release.md
           labels: automated training issue
 

--- a/.github/workflows/file-setup-issues.yml
+++ b/.github/workflows/file-setup-issues.yml
@@ -77,6 +77,14 @@ jobs:
           content-filepath: ./setup-issue-templates/copy-completed-notebooks.md
           labels: automated training issue, blocked
 
+      # Issue for customizing participant-information.md
+      - name: Create issue for updating participant-information.md
+        uses: peter-evans/create-issue-from-file@v4.0.0
+        with:
+          title: Update in-person logistics in `participant-information.md`
+          content-filepath: ./setup-issue-templates/update-participant-information.md
+          labels: automated training issue
+
       # Issue for creating a final version of schedule
       - name: Create final schedule issue
         uses: peter-evans/create-issue-from-file@v4.0.0

--- a/README.md
+++ b/README.md
@@ -14,30 +14,14 @@ We recommend setting the new repository to public.
 
 ## Customizing the new repository for an individual training workshop
 
-We have set up two [manually-triggered GitHub Actions](https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow) to support setting up this new repository.
-To run a GitHub action, navigate to the "Actions" tab.
+We have set up a [manually-triggered GitHub Action](https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow) to support setting up this new repository.
+When triggered, this action will file a series of issues comprising tasks that should be completed before the start of a workshop.
+You should trigger this action once the [`training-modules` repository](https://github.com/AlexsLemonade/training-modules) tag for the given workshop has been created, as one of the _first steps_ of setting up your new repository.
+
+To run this action, navigate to the "Actions" tab.
 On the left, you will see all available workflows.
-Click the name of the workflow you would like to run, and then click the "Run workflow" dropdown button.
-
-The subsections below introduce the two workflows you should run for setup.
-
-### `Manually trigger issue creation for standard set up`
-
-This action will automatically file a series of issues representing tasks that should be completed before the start of a workshop.
-This action takes one required input, the [`training-modules` repository](https://github.com/AlexsLemonade/training-modules) release tag you would like to associate with the workshop.
-
-You should trigger this action once the `training-modules` repository tag has been created; this should happen as one of the _first steps_ of setting up your new repository.
-
-### `Copy completed HTML notebooks to training website repository`
-
-This action will copy completed exercise notebooks from the `training-modules` repository to this new repository.
-Specifically, this action will open a Pull Request (PR) to add completed notebooks to the `completed-notebooks` directory; this PR will need to approved and merged before the workshop begins.
-
-This action takes two required inputs:
-
-- The name of the workshop that will be taught.
-You can select this value from a dropdown menu when triggering the action.
-- The [`training-modules` repository](https://github.com/AlexsLemonade/training-modules) tag associated with the workshop
+Click the workflow named `Manually trigger issue creation for standard set up`, and then click the "Run workflow" dropdown button.
+You will need to provide one required input, the `training-modules` repository release tag you would like to associate with the workshop.
 
 ## Additional instructions for externally-hosted workshops
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ We use a template repository approach for maintainability.
 First, you will need to create a new repository using the [`Use the template` button](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-from-a-template).
 This will create a new repository with the same layout as this template repository under the user or organization you choose as the owner of the repository; if you are a Data Lab member running an internal training workshop, the `AlexsLemonade` organization should be the owner.
 
-We recommend setting the new repository to private (the rendered GitHub Pages website will still be public!).
+If you are using GitHub from a paid tier account (e.g., GitHub Pro, GitHub Team, or GitHub Enterprise), you can set the visibility of this repository as private; the associated GitHub Pages website will still be public.
+However, if you are using GitHub from a _free_ account (e.g., GitHub Free for individuals or organizations), you must set the visibility of this repository as public in order for GitHub Pages to be visible, as described in this [documentation](https://docs.github.com/en/pages/getting-started-with-github-pages/about-github-pages).
 
 ## Customizing the new repository for an individual training workshop
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # training-specific-template
 
 This repository is intended to serve as a template for creating a repository for an individual Data Lab workshop.
-The repository structure and use of GitHub pages is intended to gather all material required to administer a workshop in one user-friendly place.
+The repository structure and use of GitHub Pages is intended to gather all material required to administer a workshop in one user-friendly place.
 We use a template repository approach for maintainability.
 
 ## Creating a repository for an individual training workshop
@@ -9,7 +9,7 @@ We use a template repository approach for maintainability.
 First, you will need to create a new repository using the [`Use the template` button](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-from-a-template).
 This will create a new repository with the same layout as this template repository under the user or organization you choose as the owner of the repository; if you are a Data Lab member running an internal training workshop, the `AlexsLemonade` organization should be the owner.
 
-We recommend setting the new repository to private, _unless_ you are working from an unpaid GitHub account/organization.
+We recommend setting the new repository to private (the rendered GitHub Pages website will still be public!).
 
 ## Customizing the new repository for an individual training workshop
 
@@ -28,11 +28,11 @@ _More detailed instructions and/or improvements coming soon._
 
 ## Local development
 
-It can be helpful to build the GitHub pages site locally to check that passing parameter values is working as expected.
+It can be helpful to build the GitHub Pages site locally to check that passing parameter values is working as expected.
 
-### Installing GitHub pages dependencies locally
+### Installing GitHub Pages dependencies locally
 
-Installing the dependencies for GitHub pages is best done in a separate ruby environment, managed by [`rbenv`](https://github.com/rbenv/) and [Bundler](https://bundler.io)
+Installing the dependencies for GitHub Pages is best done in a separate ruby environment, managed by [`rbenv`](https://github.com/rbenv/) and [Bundler](https://bundler.io)
 
 The following instructions were tested for installation on macOS, but installation on other systems should be similar.
 

--- a/README.md
+++ b/README.md
@@ -6,56 +6,43 @@ We use a template repository approach for maintainability.
 
 ## Creating a repository for an individual training workshop
 
-First, you will need to create a new repository.
+First, you will need to create a new repository using the [`Use the template` button](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-from-a-template).
+This will create a new repository with the same layout as this template repository under the given organization or user you choose to administer the repository; if you are a Data Lab member running an internal training workshop, the `AlexsLemonade` organization should administer the new repository.
 
-### Data Lab workshops
-
-This repository can be used as a template by anyone with read permissions.
-Select the [`Use the template` button](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-from-a-template) and create the repository under the organization (typically `AlexsLemonade`) or user you would like to administer the repository.
-We recommend setting the new repository to public. (When you use GitHub pages on a private repository, those pages are publicly accessible anyway.)
-
-### Workshops hosted by others
-
-If you are an external user, you can either [file an issue to request read access](https://github.com/AlexsLemonade/training-specific-template/issues/new?assignees=&labels=request&template=request-read-access-to-use-template-for-a-workshop.md&title=%5BRequest+read+access%5D+) or fork the repository.
-If you request read access and it is granted, follow [the instructions above](#data-lab-workshops).
-To fork the repository, [follow the GitHub instructions for forking a repository](https://help.github.com/en/github/getting-started-with-github/fork-a-repo).
-
-**There are currently some important limitations to using this repository as a template for externally-hosted workshop.**
-If you are not using the Data Lab hosted RStudio Server, there are a number of instructions in this repository that are about distributing credentials and logging into that server.
-In addition, we currently assume that instruction materials for training can be tied to a specific release in the [`AlexsLemonade/training-modules`](https://github.com/AlexsLemonade/training-modules) repository.
-_More detailed instructions and/or improvements coming soon._
+We recommend setting the new repository to public.
+(When you use GitHub pages on a private repository, those pages are publicly accessible anyway.)
 
 ## Customizing the new repository for an individual training workshop
 
-To customize this repository for an individual workshop, you should follow the checklist below.
-You can use GitHub Actions to trigger creating issues that correspond to these items (see [below](#manually-triggering-issue-creation-with-github-actions)).
+We have set up two [manually-triggered GitHub Actions](https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow) to support setting up this new repository.
+To run a GitHub action, navigate to the "Actions" tab.
+On the left, you will see all available workflows.
+Click the name of the workflow you would like to run, and then click the "Run workflow" dropdown button.
 
-- [ ] Turn on GitHub pages under `Settings`.
-- [ ] _Optional but highly recommended:_ Turn on branch protection for the repository's default branch (e.g., `main`) such that pull requests are required before merging.
-- [ ] _Optional:_ Delete or alter the issue templates (`.github/ISSUE_TEMPLATE`); the ones that will be included are tailored for the template repository.
-- [ ] Delete the irrelevant `*-workshop` folder.
-If your workshop is a virtual workshop, remove the `in-person-workshop` folder.
-If your workshop is an in-person workshop, remove the `virtual-workshop` folder.
-	- If you're running an in-person workshop, you will not need the `virtual-setup` folder, either.
-- [ ] Rename the relevant `*-workshop` folder to `workshop`.
-For a virtual workshop, `virtual-workshop` should be renamed to `workshop`.
-Changing this folder name will make several links in the repository work–there are instances where we link to a schedule with `../workshop/SCHEDULE.md`, for example.
-- [ ] Add PDF copies of your slides to `slides`.
-_Optional_: remove the `.gitkeep` file from `slides`.
-- [ ] Update `_config.yaml` to use values that are relevant for your workshop such as the Docker repository and tag that you will be using for the workshop. [We use jekyll variable substitution as part of this template](https://jekyllrb.com/docs/includes/#passing-parameter-variables-to-includes).
-- [ ] Update the pages that will appear in the header (`header_pages:`) in `_config.yaml` as needed.
-Any page that appears in the header should have a navigation title (`nav_title:`) in its YAML header.
-- [ ] Update `workshop/SCHEDULE.md` to point to appropriate materials for your workshop.
-	- Add relative links to PDFs in `slides` to the schedule.
-	- Add relative links to completed notebooks in `completed-notebooks` to the schedule.
-- [ ] Remove these instructions (and most likely the local development instructions below) from this README!
-We recommend that you link to `<url for repository's GitHub pages>/workshop/HOME` in the README, as this is where you will likely want most users to start to interact with the repository.
+The subsections below introduce the two workflows you should run for setup.
 
-### Manually triggering issue creation with GitHub Actions
+### `Manually trigger issue creation for standard set up`
 
-If you would like to automatically create issues corresponding to the tasks that are required for customizing this repository, you can manually trigger a workflow once you have created your new repository.
-Navigate to `Actions` and select `Manually trigger issue creation for standard set up` from under `All workflows`.
-Use the `Run workflow` drop down menu; you will be required to input the appropriate `training-modules` release tag for your training workshop.
+This action will automatically file a series of issues representing tasks that should be completed before the start of a workshop.
+This action takes one required input, the [`training-modules` repository](https://github.com/AlexsLemonade/training-modules) release tag you would like to associate with the workshop.
+
+You should trigger this action once the `training-modules` repository tag has been created; this should happen as one of the _first steps_ of setting up your new repository.
+
+### `Copy completed HTML notebooks to training website repository`
+
+This action will copy completed exercise notebooks from the `training-modules` repository to this new repository.
+Specifically, this action will open a Pull Request (PR) to add completed notebooks to the `completed-notebooks` directory; this PR will need to approved and merged before the workshop begins.
+
+This action takes two required inputs:
+
+- The name of the workshop that will be taught.
+You can select this value from a dropdown menu when triggering the action.
+- The [`training-modules` repository](https://github.com/AlexsLemonade/training-modules) tag associated with the workshop
+
+## Additional instructions for externally-hosted workshops
+
+_More detailed instructions and/or improvements coming soon._
+
 
 ## Local development
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ We use a template repository approach for maintainability.
 First, you will need to create a new repository using the [`Use the template` button](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-from-a-template).
 This will create a new repository with the same layout as this template repository under the user or organization you choose as the owner of the repository; if you are a Data Lab member running an internal training workshop, the `AlexsLemonade` organization should be the owner.
 
-We recommend setting the new repository to public.
-(When you use GitHub pages on a private repository, those pages are publicly accessible anyway.)
+We recommend setting the new repository to private, _unless_ you are working from an unpaid GitHub account/organization.
 
 ## Customizing the new repository for an individual training workshop
 
@@ -21,7 +20,6 @@ You should trigger this action once the [`training-modules` repository](https://
 To run this action, navigate to the "Actions" tab.
 On the left, you will see all available workflows.
 Click the workflow named `Manually trigger issue creation for standard set up`, and then click the "Run workflow" dropdown button.
-You will need to provide one required input, the `training-modules` repository release tag you would like to associate with the workshop.
 
 ## Additional instructions for externally-hosted workshops
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ First, you will need to create a new repository using the [`Use the template` bu
 This will create a new repository with the same layout as this template repository under the user or organization you choose as the owner of the repository; if you are a Data Lab member running an internal training workshop, the `AlexsLemonade` organization should be the owner.
 
 If you are using GitHub from a paid tier account (e.g., GitHub Pro, GitHub Team, or GitHub Enterprise), you can set the visibility of this repository as private; the associated GitHub Pages website will still be public.
-However, if you are using GitHub from a _free_ account (e.g., GitHub Free for individuals or organizations), you must set the visibility of this repository as public in order for GitHub Pages to be visible, as described in this [documentation](https://docs.github.com/en/pages/getting-started-with-github-pages/about-github-pages).
+However, if you are using GitHub from a _free_ account (e.g., GitHub Free for individuals or organizations), you must set the visibility of this repository as public in order for GitHub Pages to be active, as described in [this documentation](https://docs.github.com/en/pages/getting-started-with-github-pages/about-github-pages).
 
 ## Customizing the new repository for an individual training workshop
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ We use a template repository approach for maintainability.
 ## Creating a repository for an individual training workshop
 
 First, you will need to create a new repository using the [`Use the template` button](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-from-a-template).
-This will create a new repository with the same layout as this template repository under the given organization or user you choose to administer the repository; if you are a Data Lab member running an internal training workshop, the `AlexsLemonade` organization should administer the new repository.
+This will create a new repository with the same layout as this template repository under the user or organization you choose as the owner of the repository; if you are a Data Lab member running an internal training workshop, the `AlexsLemonade` organization should be the owner.
 
 We recommend setting the new repository to public.
 (When you use GitHub pages on a private repository, those pages are publicly accessible anyway.)

--- a/setup-issue-templates/update-participant-information.md
+++ b/setup-issue-templates/update-participant-information.md
@@ -1,0 +1,3 @@
+If you are running an **in-person workshop**, you should update content in `workshop/participant-information.md` to contain relevant logistics for this workshop.
+
+If you are running a **remote** workshop, there is nothing to do here - you can close this issue for free!

--- a/setup-issue-templates/user-facing-readme.md
+++ b/setup-issue-templates/user-facing-readme.md
@@ -1,3 +1,5 @@
 Remove customization and development instructions from the README.
 
-Link to `<url for repository's GitHub pages>/workshop/HOME` in the README, as this is where we want most users to start to interact with the repository. 
+Link to `<url for repository's GitHub pages>/workshop/HOME` in the README, as this is where we want most users to start to interact with the repository.
+
+For an example of a previous README, see here: <https://github.com/AlexsLemonade/2023-january-training/blob/main/README.md>

--- a/setup-issue-templates/user-facing-readme.md
+++ b/setup-issue-templates/user-facing-readme.md
@@ -1,5 +1,5 @@
 Remove customization and development instructions from the README.
 
-Link to `<url for repository's GitHub pages>/workshop/HOME` in the README, as this is where we want most users to start to interact with the repository.
+Link to `<url for repository's GitHub Pages>/workshop/HOME` in the README, as this is where we want most users to start to interact with the repository.
 
 For an example of a previous README, see here: <https://github.com/AlexsLemonade/2023-january-training/blob/main/README.md>


### PR DESCRIPTION
Closes #112

This PR updates the `README` with instructions for setting up. While working on this, I also thought of one more setup issue that we should have - customizing participant info - and added to the GHA.

I ended up removing the issues checklist from the README in favor of just telling folks to run the github action, which I think is much simpler. I also left a section in the README to circle back to (will open an issue for it) about additional external instructions. One reason to circle back to this is that, honestly, I can't think of any external-specific instructions... can you? Do we even need that subsection?

Any feedback on phrasing, organization, preference to restore that checklist, let me know!