### PR TITLE
Change master to main

### DIFF
--- a/workshop/working-with-your-own-data.md
+++ b/workshop/working-with-your-own-data.md
@@ -35,7 +35,7 @@ If you are retrieving your data from online, perhaps from a publicly available r
 <img src="screenshots/rstudio-session-terminal.png" alt = "RStudio terminal tab" width="600">
 
 
-**Step 2)** Copy over the [`wget` template script]({{site.repository_url}}/tree/master/additional-resources/template-scripts/wget-TEMPLATE.sh).
+**Step 2)** Copy over the [`wget` template script]({{site.repository_url}}/tree/main/additional-resources/template-scripts/wget-TEMPLATE.sh).
 
 You'll find the `wget` template script in the `shared-data/template-scripts/` directory.
 In the RStudio Server, you can click the check mark next to the file name, then go to `More` > and choose `Copy To` to make a copy with a new name somewhere convenient in your home directory.

--- a/workshop/workshop-materials.md
+++ b/workshop/workshop-materials.md
@@ -5,7 +5,7 @@ nav_title: Materials
 
 ### Slides
 
-PDF versions of the slides we present in this workshop can be found in the [slides directory]({{site.repository_url}}/tree/master/slides) of the `{{site.repository}}` repository, and are also linked to directly from the [schedule](SCHEDULE.md).
+PDF versions of the slides we present in this workshop can be found in the [slides directory]({{site.repository_url}}/tree/main/slides) of the `{{site.repository}}` repository, and are also linked to directly from the [schedule](SCHEDULE.md).
 
 ### Module Structure
 


### PR DESCRIPTION
It's not the `master`->`main` you wanted, but it _is_ a `master`->`main`! This repo already uses `main`, so we should actually use it.

Here are the remaining `master`'s from the top level. I'm pretty sure I got them all.

```
> rm -rf _site
> grep -r "master" .

./workshop/working-with-your-own-data.md:We'd suggest creating a master password or using `Do not save password`.
./additional-resources/bulk-resources.md:Please see the notebook [`RNA-seq/00c-tximeta_other_species.Rmd`](https://github.com/AlexsLemonade/training-modules/blob/master/RNA-seq/00c-tximeta_other_species.Rmd) for details on how to set this up.
./_config.yaml:# We use master to make development easier
./_config.yaml:release_tag: master
./.github/workflows/copy-completed-notebooks.yml:        default: "master"
```