### PR TITLE
Fix copy completed notebook GHA

### DIFF
--- a/.github/workflows/copy-completed-notebooks.yml
+++ b/.github/workflows/copy-completed-notebooks.yml
@@ -56,7 +56,7 @@ jobs:
           #  bulk RNA-seq: RNA-seq/
 
           # Path to copy notebooks to
-          target_path=website/completed-notebooks/
+          target_path=website/completed-notebooks
 
           # Create array of directories from which notebooks should be copied
           case "${{ github.event.inputs.training-module }}" in
@@ -80,6 +80,7 @@ jobs:
 
           # Copy all completed notebooks from the given directories
           for module in ${modules[@]}; do
+            mkdir -p ${target_path}/${module}
             cp training-modules/${module}/[0-9]*.html ${target_path}/${module}
           done
 


### PR DESCRIPTION
While testing out actions in my own repo as part of #147, I found a few syntax bugs. Those are fixed here. The main bug was missing a `mkdir`, but also I removed an extra slash which wasn't hurting anyone but shouldn't be there anyways.

Proof it now works: https://github.com/tardigrades4life/tst/pull/11