### PR TITLE
Clarify how to update the in-person logistics page

### DIFF
--- a/setup-issue-templates/update-participant-information.md
+++ b/setup-issue-templates/update-participant-information.md
@@ -1,3 +1,6 @@
-If you are running an **in-person workshop**, you should update content in `workshop/participant-information.md` to contain relevant logistics for this workshop.
+- If you are running an **in-person workshop**, you should update content in `workshop/local-participant-information.md` to contain relevant logistics for this workshop.
+  - Note that this page will not be directly displayed on the website.
+    Instead, its content will automatically appear within the `workshop/workshop-logistics.md` page when the `_config.yml` file field `workshop_type` is set to `"in-person"`.
+    _You should therefore not update the  `workshop/workshop-logistics.md` file._
 
-If you are running a **remote** workshop, there is nothing to do here - you can close this issue for free!
+- If you are running a **remote** workshop, there is nothing to do here - you can close this issue for free!

--- a/setup-issue-templates/update-participant-information.md
+++ b/setup-issue-templates/update-participant-information.md
@@ -1,6 +1,6 @@
 - If you are running an **in-person workshop**, you should update content in `workshop/local-participant-information.md` to contain relevant logistics for this workshop.
   - Note that this page will not be directly displayed on the website.
-    Instead, its content will automatically appear within the `workshop/workshop-logistics.md` page when the `_config.yml` file field `workshop_type` is set to `"in-person"`.
+    Instead, its content will automatically appear within the `workshop/workshop-logistics.md` page when the `_config.yml` field `workshop_type` is set to `"in-person"`.
     _You should therefore not update the  `workshop/workshop-logistics.md` file._
 
 - If you are running a **remote** workshop, there is nothing to do here - you can close this issue for free!

--- a/workshop/local-participant-information.md
+++ b/workshop/local-participant-information.md
@@ -1,6 +1,10 @@
 
-<!-- Please update this file to reflect logistics for the workshop being taught. -->
+<!--
+INSTRUCTIONS:
 
+Please update this file to reflect logistics for the workshop being taught.
+Content in this page will automatically be rendered in the `workshop-logistics.md` page, which should _not_ be modified.
+-->
 
 
 ## Workshop Location

--- a/workshop/workshop-logistics.md
+++ b/workshop/workshop-logistics.md
@@ -3,6 +3,13 @@ title: Workshop Logistics
 nav_title: Logistics
 ---
 
+<!--
+DO NOT MODIFY THIS FILE!
+If you want to update in-person logistics, please instead update the `local-participant-information.md` file.
+-->
+
+
+
 **Table of contents**
 
 * TOC goes here


### PR DESCRIPTION
This PR makes a few updates that hopefully clarify how to update in-person logistics for a given workshop:

- The issue template itself now provides more context for while file to modify and why
- The relevant markdown files now contain guiding comments at the top instructing how to update contents

Let me know if this is helpful, or if other instructions would be more helpful!