### PR TITLE
Training template updates

### DIFF
--- a/components/dictionary.txt
+++ b/components/dictionary.txt
@@ -24,6 +24,7 @@ cheatsheet
 cheatsheets
 checkmarks
 compositional
+contactless
 COVID
 customizable
 Cynwyd

--- a/setup-issue-templates/draft-schedule.md
+++ b/setup-issue-templates/draft-schedule.md
@@ -1,4 +1,2 @@
-Update `workshop/SCHEDULE.md` to point to appropriate materials for your workshop.
-
-  - Add relative links to PDFs in `slides` to the schedule.
-  - Use relative links to display rendered versions of R Notebooks in `completed-notebooks`.
+Update `workshop/SCHEDULE.md` to create a draft workshop schedule with workshop modules, dates, and times.
+Links to the exercise notebooks can also be added.

--- a/setup-issue-templates/final-schedule.md
+++ b/setup-issue-templates/final-schedule.md
@@ -1,1 +1,5 @@
 Finalize the schedule once all content has been completed.
+This may entail:
+
+- Adding relative links to PDFs in `slides` to the schedule.
+- Adding relative links to display rendered versions of R Notebooks in `completed-notebooks`.

--- a/workshop/HOME.md
+++ b/workshop/HOME.md
@@ -17,9 +17,9 @@ Dates: {{site.start_date}} through {{site.end_date}}
 
 ### Pre-workshop Prep
 
-* Please review the [Code of Conduct](../code-of-conduct.md).
+* Please review the **[Code of Conduct](../code-of-conduct.md)**.
 {%- if site.workshop_content != "advanced-single-cell" %}
-* If you are new to using R, we've [assembled some resources for getting starting with R](../additional-resources/R-resources.md#pre-workshop-prep-for-r-programming) that can optionally help prepare you for the workshop.
+* If you are new to using R, we've **[assembled some resources for getting starting with R](../additional-resources/R-resources.md#pre-workshop-prep-for-r-programming)** that can optionally help prepare you for the workshop.
 {%- endif %}
 * Please review the **[software platforms](../software-setup/software-setup-instructions.md)** we will be using to familiarize yourself with our procedures.
   * You will also need to install
@@ -30,8 +30,8 @@ Dates: {{site.start_date}} through {{site.end_date}}
 `Slack`
 {%- endcase -%}, as described in the link above.
 
-* Sign up for the **Cancer Data Science** Slack workspace at <http://ccdatalab.org/slack>. Please use your full name in your profile, so we can find you easily and add you to the private meeting channel.
-* Once you have been given your username and temporary password, follow [these instructions](../software-setup/rstudio-login.md) to log in to our RStudio server and change your password.
+* Sign up for the **Cancer Data Science Slack workspace** at <http://ccdatalab.org/slack>. Please use your full name in your profile, so we can find you easily and add you to the private meeting channel.
+* Once you have been given your username and temporary password, **[follow these instructions](../software-setup/rstudio-login.md)** to log in to our RStudio server and change your password.
 
 ## Schedule
 

--- a/workshop/HOME.md
+++ b/workshop/HOME.md
@@ -18,7 +18,9 @@ Dates: {{site.start_date}} through {{site.end_date}}
 ### Pre-workshop Prep
 
 * Please review the [Code of Conduct](../code-of-conduct.md).
+{%- if site.workshop_content != "advanced-single-cell" %}
 * If you are new to using R, we've [assembled some resources for getting starting with R](../additional-resources/R-resources.md#pre-workshop-prep-for-r-programming) that can optionally help prepare you for the workshop.
+{%- endif %}
 * Please review the **[software platforms](../software-setup/software-setup-instructions.md)** we will be using to familiarize yourself with our procedures.
   * You will also need to install
 {%- case site.workshop_type -%}

--- a/workshop/SCHEDULE.md
+++ b/workshop/SCHEDULE.md
@@ -7,13 +7,14 @@ nav_title: Schedule
 <!--See an example from a past in-person workshop here: https://github.com/AlexsLemonade/2024-december-training/blob/main/workshop/SCHEDULE.md -->
 
 
-| Time        | Topic                                          |
-|-------------|------------------------------------------------|
-| **Day 1**   | **Date** <br> <!--uncomment and add link: [Module]()-->                      |
-| 12:00 PM    | Welcome, Introductions and Getting Started     <br>[Welcome Slides (PDF)](../slides/Workshop_Introduction.pdf)|
-| 5:00        | End             |
-| **Day 2**   | **Date**  |
-| **Day 3**   | **Date**  |
-| **Day 4**   | **Date**  |
-| **Day 5**   | **Date**  |
-| 5:00        | Adjourn   |
+| Time        | Topic
+|-------------|------------------------------------------------
+| **Day 1**   | **Date** <br> **Topic**
+| 12:00 PM    | Welcome, Introductions and Getting Started
+|             | [Welcome Slides (PDF)](../slides/Workshop_Introduction.pdf)
+| 5:00        | End
+| **Day 2**   | **Date**
+| **Day 3**   | **Date**
+| **Day 4**   | **Date**
+| **Day 5**   | **Date**
+| 5:00        | Adjourn

--- a/workshop/SCHEDULE.md
+++ b/workshop/SCHEDULE.md
@@ -3,8 +3,8 @@ title: Workshop Schedule
 nav_title: Schedule
 ---
 
-<!--See an example from a past remote workshop here: https://github.com/AlexsLemonade/2023-may-training/blob/main/workshop/SCHEDULE.md -->
-<!--See an example from a past in-person workshop here: https://github.com/AlexsLemonade/2023-june-training/blob/main/workshop/SCHEDULE.md -->
+<!--See an example from a past remote workshop here: https://github.com/AlexsLemonade/2024-june-training/blob/main/workshop/SCHEDULE.md -->
+<!--See an example from a past in-person workshop here: https://github.com/AlexsLemonade/2024-december-training/blob/main/workshop/SCHEDULE.md -->
 
 
 | Time        | Topic                                          |

--- a/workshop/local-participant-information.md
+++ b/workshop/local-participant-information.md
@@ -29,7 +29,7 @@ If you have trouble finding the building or the room on the first day of trainin
 **Public transportation**
 
 * SEPTA is the public transportation system in Philadelphia and the surrounding area.
-* At the airport, and at some SEPTA train stations, you can purchase a SEPTA key card. There are a variety of fare options that can be loaded onto a key card for use on public transportation. SEPTA also accepts cash for travel on any of its transit services.
+* You can use cash or contactless pay (credit/debit card or Apple/Google/Samsung Pay) on SEPTA subways and buses.
 * Please refer to the [SEPTA website](https://www5.septa.org/travel/) for more information. (**Note:** The [SEPTA trip planner](https://beta-plan.septa.org/#/) may be a helpful tool if you plan to travel around the city during your stay.)
 
 **Other**

--- a/workshop/working-with-your-own-data.md
+++ b/workshop/working-with-your-own-data.md
@@ -314,7 +314,7 @@ Finally, drag the installed `FileZilla` application icon to your `Applications` 
 
 The first time you open `FileZilla`, you may see this warning message; click `Open`.
 
-<img src="screenshots/filezilla-mac-allow.png" alt = "Allow macOS to use FileZilla application" screen" width="300">
+<img src="screenshots/filezilla-mac-allow.png" alt = "Allow macOS to use FileZilla application" width="300">
 
 
 #### Windows installation


### PR DESCRIPTION
This PR closes a handful of small issues:

- Closes #164
  - `workshop/SCHEDULE.md` example links were updated with more recent workshop schedules that use the current version of this repo
- Closes #165 
  - The draft and final schedule issue templates were updated to more closely reflect the changes we make at each stage of building the schedule. I didn't add any anchor links as the issue describes, since it didn't actually seem necessary given the other changes.
- Closes #172
  - Update SEPTA sentence. The future is now!
  - Added an `if` statement to not print the "new to R?" bullet on the home page if we're teaching an advanced workshop.     
- Closes #174 
  - Fixes an HTML bug where a figure wasn't rendering. This change is the same as https://github.com/AlexsLemonade/2024-december-training/pull/24  