### PR TITLE
Make instructions R version agnostic

### DIFF
--- a/additional-resources/single-cell-resources.md
+++ b/additional-resources/single-cell-resources.md
@@ -44,7 +44,7 @@ Click on the project name to see an abstract and other information for the proje
 
 You can then select "Project Matrices" from the left side to download the processed single-cell expression data.
 Scroll down to the "DCP Generated Matrices" section on the "Project Matrices" page, as the data here will be uniformly processed and in a standard data format.
-That format is called `loom`, and we can read it into `R` in a fairly straightforward way.
+That format is called `loom`, and we can read it into R in a fairly straightforward way.
 Once you find a loom file listed (not all projects have one, unfortunately), you have two options:
 
 1. Click the "Copy download link" button (the tiny clipboard icon) and then use that URL to download the file directly to the RStudio server [following these instructions](../workshop/working-with-your-own-data.md#loading-data-from-a-website).

--- a/additional-resources/using-environments-post-workshop.md
+++ b/additional-resources/using-environments-post-workshop.md
@@ -139,7 +139,7 @@ Once stopped, this icon will switch to a **Play** button which you can click to 
 
 ## Use renv post-workshop
 
-Using `renv` will allow you to replicate the _`R` environment only_ used in the training workshop, but not other command-line tools.
+Using `renv` will allow you to replicate the _R environment only_ used in the training workshop, but not other command-line tools.
 
 This link provides full documentation for the `renv` package: <https://rstudio.github.io/renv/articles/renv.html>.
 

--- a/additional-resources/using-environments-post-workshop.md
+++ b/additional-resources/using-environments-post-workshop.md
@@ -150,8 +150,9 @@ This link provides full documentation for the `renv` package: <https://rstudio.g
 
 #### R, RStudio, and renv
 
-While not strictly required, we recommend that you install the same `R` version that we used during the workshop (version `4.2.3`).
-(Protip: You might find the [`rig` software](https://github.com/r-lib/rig) useful for getting this specific `R` version!)
+While not strictly required, we recommend that you install the same `R` version that we used during the workshop.
+You can find the specific `R` version from the Console prompt in the training RStudio Server. 
+(Protip: You might find the [`rig` software](https://github.com/r-lib/rig) useful for getting this specific `R` version as well as managing multiple `R` versions!)
 
 You can download R and RStudio following [these instructions](https://posit.co/download/rstudio-desktop/).
 
@@ -162,7 +163,7 @@ You can then launch RStudio and install the `renv` package from CRAN: `install.p
 
 You may need to install a few more things (if you have not previously installed them) so that the R packages `renv` installs can build properly.
 
-* **Windows** users will need to install [`Rtools42` for Windows](https://cran.r-project.org/bin/windows/Rtools/rtools42/rtools.html); this will allow you to compile R packages.
+* **Windows** users will need to install [`Rtools` for Windows](https://cran.r-project.org/bin/windows/Rtools); this will allow you to compile R packages.
   * `Rtools` is generally specific to a given R version, so if you have newly downloaded R, you will need to download the correct `Rtools` version for it as well.
 * **macOS** users will need to install `Xcode` developer command line tools and a GNU `fortran` compiler (`gfortran`), as described [here](https://mac.r-project.org/tools/).
   * You can install command line tools by launching `Terminal` and entering

--- a/additional-resources/using-environments-post-workshop.md
+++ b/additional-resources/using-environments-post-workshop.md
@@ -150,9 +150,9 @@ This link provides full documentation for the `renv` package: <https://rstudio.g
 
 #### R, RStudio, and renv
 
-While not strictly required, we recommend that you install the same `R` version that we used during the workshop.
-You can find the specific `R` version from the Console prompt in the training RStudio Server. 
-(Protip: You might find the [`rig` software](https://github.com/r-lib/rig) useful for getting this specific `R` version as well as managing multiple `R` versions!)
+While not strictly required, we recommend that you install the same R version that we used during the workshop.
+You can find the specific R version from the Console prompt in the training RStudio Server. 
+(Protip: You might find the [`rig` software](https://github.com/r-lib/rig) useful for getting this specific R version as well as managing multiple R versions!)
 
 You can download R and RStudio following [these instructions](https://posit.co/download/rstudio-desktop/).
 
@@ -163,7 +163,7 @@ You can then launch RStudio and install the `renv` package from CRAN: `install.p
 
 You may need to install a few more things (if you have not previously installed them) so that the R packages `renv` installs can build properly.
 
-* **Windows** users will need to install [`Rtools` for Windows](https://cran.r-project.org/bin/windows/Rtools); this will allow you to compile R packages.
+* **Windows** users will need to install the version of [`Rtools` for Windows](https://cran.r-project.org/bin/windows/Rtools) that matches your R version; this will allow you to compile R packages.
   * `Rtools` is generally specific to a given R version, so if you have newly downloaded R, you will need to download the correct `Rtools` version for it as well.
 * **macOS** users will need to install `Xcode` developer command line tools and a GNU `fortran` compiler (`gfortran`), as described [here](https://mac.r-project.org/tools/).
   * You can install command line tools by launching `Terminal` and entering


### PR DESCRIPTION
Closes #179 

Taking care of small icebox issues (no rush to review!). This PR removes R version info from the environment instructions to make it more general for longer-term use without needing to edit again.